### PR TITLE
upgrade make and helm for different OS

### DIFF
--- a/make/helm.mk
+++ b/make/helm.mk
@@ -4,8 +4,40 @@ HELM_VERSION = v3.15.0
 HELM_V_BINARY := $(LOCALBIN)/helm-$(HELM_VERSION)
 
 $(HELM_V_BINARY): $(LOCALBIN)  ## Installs helm in $PROJECT_DIR/bin
-# For AMD64 / x86_64
-ifeq ($(shell uname -p),x86_64)
+# Download helm binary depending on architecture and OS
+ifeq ($(shell uname -s),Darwin)
+  # macOS
+  ifeq ($(shell uname -m),arm64)
+	@{ \
+	set -e ;\
+	curl -Lo helm.tar.gz https://get.helm.sh/helm-$(HELM_VERSION)-darwin-arm64.tar.gz ;\
+	tar -zxvf helm.tar.gz ;\
+	mv darwin-arm64/helm $@ ;\
+	chmod +x $@ ;\
+	rm -rf darwin-arm64 helm.tar.gz ;\
+	}
+  else
+	@{ \
+	set -e ;\
+	curl -Lo helm.tar.gz https://get.helm.sh/helm-$(HELM_VERSION)-darwin-amd64.tar.gz ;\
+	tar -zxvf helm.tar.gz ;\
+	mv darwin-amd64/helm $@ ;\
+	chmod +x $@ ;\
+	rm -rf darwin-amd64 helm.tar.gz ;\
+	}
+  endif
+else
+  # Linux
+  ifeq ($(shell uname -m),aarch64)
+	@{ \
+	set -e ;\
+	curl -Lo helm.tar.gz https://get.helm.sh/helm-$(HELM_VERSION)-linux-arm64.tar.gz ;\
+	tar -zxvf helm.tar.gz ;\
+	mv linux-arm64/helm $@ ;\
+	chmod +x $@ ;\
+	rm -rf linux-arm64 helm.tar.gz ;\
+	}
+  else
 	@{ \
 	set -e ;\
 	curl -Lo helm.tar.gz https://get.helm.sh/helm-$(HELM_VERSION)-linux-amd64.tar.gz ;\
@@ -14,18 +46,9 @@ ifeq ($(shell uname -p),x86_64)
 	chmod +x $@ ;\
 	rm -rf linux-amd64 helm.tar.gz ;\
 	}
+  endif
 endif
-# For ARM64
-ifeq ($(shell uname -p),aarch64)
-	@{ \
-	set -e ;\
-	curl -Lo helm.tar.gz https://get.helm.sh/helm-$(HELM_VERSION)-linux-arm64.tar.gz ;\
-	tar -zxvf helm.tar.gz ;\
-	mv linux-arm64/helm $@ ;\
-	chmod +x $@ ;\
-	rm -rf linux-amd64 helm.tar.gz ;\
-	}
-endif
+
 
 .PHONY: helm
 helm: $(HELM_V_BINARY) ## Download helm locally if necessary.

--- a/make/kind.mk
+++ b/make/kind.mk
@@ -9,13 +9,21 @@ KIND_V_BINARY := $(LOCALBIN)/kind-$(KIND_VERSION)
 kind: $(KIND_V_BINARY)
 
 $(KIND_V_BINARY): $(LOCALBIN)  ## Installs kind in $PROJECT_DIR/bin
-# For AMD64 / x86_64
-ifeq ($(shell uname -p),x86_64)
-	curl -Lo $@ https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-linux-amd64
-endif
-# For ARM64
-ifeq ($(shell uname -p),aarch64)
+# Download kind binary depending on architecture and OS
+ifeq ($(shell uname -s),Darwin)
+  # macOS
+  ifeq ($(shell uname -m),arm64)
+	curl -Lo $@ https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-darwin-arm64
+  else
+	curl -Lo $@ https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-darwin-amd64
+  endif
+else
+  # Linux
+  ifeq ($(shell uname -m),aarch64)
 	curl -Lo $@ https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-linux-arm64
+  else
+	curl -Lo $@ https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-linux-amd64
+  endif
 endif
 	chmod +x $@
 


### PR DESCRIPTION
closes #28 
**In terminal window, run:**
1. make kind-create
2. make dev

**Result**

- make kind-create now successfully creates the local kind cluster.
- make helm now correctly downloads and installs the Helm binary into the bin/ directory.
- Both kind and helm binaries are placed under bin/ and become executable.
- Tested and working on macOS (Intel & Apple Silicon), Linux).