### PR TITLE
plans column: use planpolicy ref name

### DIFF
--- a/kuadrant-dev-setup/crds/extensions.kuadrant.io_apiproduct.yaml
+++ b/kuadrant-dev-setup/crds/extensions.kuadrant.io_apiproduct.yaml
@@ -172,10 +172,10 @@ spec:
     - name: Version
       type: string
       jsonPath: .spec.version
-    - name: Plans
+    - name: Plan Policy
       type: string
-      jsonPath: .spec.plans[*].tier
-      description: Available plan tiers
+      jsonPath: ".spec.planPolicyRef.name"
+      description: Referenced PlanPolicy name
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
Small patch to the CRD

```bash
kubectl get APIProduct -A
NAMESPACE   NAME           DISPLAY NAME   VERSION   PLAN POLICY      AGE
default     test           test           v1        toystore-plans   5d2h
toystore    toystore       Toystore v3    v3        toystore-plans   7h17m
toystore    toystore-api   Toystore API   v1        toystore-plans   6d1h
toystore    toystore2      toystore2      v1        toystore-plans   5d2h
```