### PR TITLE
kind extra port mappings no longer needed

### DIFF
--- a/kuadrant-dev-setup/scripts/kind-cluster.yaml
+++ b/kuadrant-dev-setup/scripts/kind-cluster.yaml
@@ -2,9 +2,5 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-- role: control-plane
-  extraPortMappings:
-    - containerPort: 30007
-      hostPort: 7007
-      protocol: TCP
-  image: mirror.gcr.io/kindest/node:v1.30.0
+  - role: control-plane
+    image: mirror.gcr.io/kindest/node:v1.30.0


### PR DESCRIPTION
The docker port mapping of hostport 7007 is conflicting with the backend plugin listen port. And it is not needed. 