### PR TITLE
added add status feild and upgrade filtration apis

### DIFF
--- a/kuadrant-dev-setup/crds/extensions.kuadrant.io_apiproduct.yaml
+++ b/kuadrant-dev-setup/crds/extensions.kuadrant.io_apiproduct.yaml
@@ -135,6 +135,11 @@ spec:
                   url:
                     type: string
                     description: url to team page or support portal
+              publishStatus:
+                type: string
+                enum: [ Draft, Published ]
+                default: Draft
+                description: controls whether the api product appears in the backstage catalog (Draft = hidden, Published = visible)
           status:
             type: object
             properties:

--- a/plugins/kuadrant-backend/src/providers/APIProductEntityProvider.ts
+++ b/plugins/kuadrant-backend/src/providers/APIProductEntityProvider.ts
@@ -20,6 +20,7 @@ interface APIProduct {
     description?: string;
     version?: string;
     tags?: string[];
+    publishStatus?: 'Draft' | 'Published';
     plans?: Array<{
       tier: string;
       description?: string;
@@ -92,8 +93,15 @@ export class APIProductEntityProvider implements EntityProvider {
       const apiProducts = (response.items || []) as APIProduct[];
       console.log(`apiproduct provider: found ${apiProducts.length} apiproducts`);
 
+      // filter out Draft API products - only include Published ones
+      const publishedProducts = apiProducts.filter(product => {
+        const publishStatus = product.spec.publishStatus || 'Draft';  // default to Draft if not specified
+        return publishStatus === 'Published';
+      });
+      console.log(`apiproduct provider: filtered to ${publishedProducts.length} published apiproducts (${apiProducts.length - publishedProducts.length} drafts excluded)`);
+
       // transform apiproducts to backstage api entities
-      const entities = apiProducts.map(product => this.transformToEntity(product));
+      const entities = publishedProducts.map(product => this.transformToEntity(product));
       console.log(`apiproduct provider: transformed ${entities.length} entities`);
 
       // submit entities to catalog

--- a/plugins/kuadrant/src/types/api-management.ts
+++ b/plugins/kuadrant/src/types/api-management.ts
@@ -76,6 +76,7 @@ export interface APIProductSpec {
     namespace: string;
   };
   plans: Plan[];
+  publishStatus?: 'Draft' | 'Published';
   documentation?: {
     openAPISpec?: string;
     swaggerUI?: string;


### PR DESCRIPTION
closes #36 

Changes
- Added `publishStatus` field to CRD (default: `Draft`)
- Updated TypeScript types and backend interfaces
- Implemented catalog filtering: only Published APIs visible

