### PR TITLE
fixing consumer view for pending api request in kuadrant page

### DIFF
--- a/plugins/kuadrant/src/components/MyApiKeysCard/MyApiKeysCard.tsx
+++ b/plugins/kuadrant/src/components/MyApiKeysCard/MyApiKeysCard.tsx
@@ -76,7 +76,7 @@ export const MyApiKeysCard = () => {
 
   const allRequests = requests || [];
   const approvedRequests = allRequests.filter((r: APIKeyRequest) => r.status?.phase === 'Approved');
-  const pendingRequests = allRequests.filter((r: APIKeyRequest) => r.status?.phase === 'Pending');
+  const pendingRequests = allRequests.filter((r: APIKeyRequest) => !r.status?.phase || r.status.phase === 'Pending');
   const rejectedRequests = allRequests.filter((r: APIKeyRequest) => r.status?.phase === 'Rejected');
 
   const toggleKeyVisibility = (keyName: string) => {


### PR DESCRIPTION
before this change the if a consumer made an apikey request and tried to view it in the kuadrant page it wouldnt show up.