### PR TITLE
Addition of display for approval modes on API product info page

### DIFF
--- a/plugins/kuadrant/src/components/ApiProductInfoCard/ApiProductInfoCard.tsx
+++ b/plugins/kuadrant/src/components/ApiProductInfoCard/ApiProductInfoCard.tsx
@@ -82,6 +82,22 @@ export const ApiProductInfoCard = () => {
                 </Box>
               )}
             </Box>
+            <Box mt={2}>
+              <Typography variant="body2" component="div">
+                <strong>Approval Mode:</strong>{' '}
+                <Chip
+                  label={(spec.approvalMode || 'manual') === 'automatic' ? 'Automatic' : 'Manual'}
+                  size="small"
+                  color={(spec.approvalMode || 'manual') === 'automatic' ? 'primary' : 'default'}
+                  style={{ marginLeft: 8 }}
+                />
+              </Typography>
+              <Typography variant="caption" color="textSecondary" style={{ marginTop: 4, display: 'block' }}>
+                {(spec.approvalMode || 'manual') === 'automatic'
+                  ? 'API keys are created immediately when requested'
+                  : 'API keys require manual approval before creation'}
+              </Typography>
+            </Box>
           </Box>
         </InfoCard>
       </Grid>


### PR DESCRIPTION
closes #56 

Addition of display for approval modes on API product info page. If API Product is updated page needs to be refreshed to represent correct value.

<img width="1920" height="1003" alt="image" src="https://github.com/user-attachments/assets/d86bab65-12c9-465c-99f0-8b6a5a8f3005" />
