### PR TITLE
55 openapi spec url not properly displayed in definition tab

### DIFF
--- a/kuadrant-dev-setup/Makefile
+++ b/kuadrant-dev-setup/Makefile
@@ -132,6 +132,8 @@ demo-install:
 	@echo "installing toystore demo resources..."
 	@kubectl apply -f demo/toystore-demo.yaml
 	@kubectl apply -f demo/additional-demos.yaml
+	# temp solution until developer-portal-controller does this
+	@kubectl patch apiproduct toystore-api -n toystore --subresource status --type=merge --patch "$$(cat demo/toystore-status.yaml)"
 	@echo ""
 	@echo "demo resources installed!"
 	@echo ""

--- a/kuadrant-dev-setup/crds/extensions.kuadrant.io_apiproduct.yaml
+++ b/kuadrant-dev-setup/crds/extensions.kuadrant.io_apiproduct.yaml
@@ -10,195 +10,204 @@ spec:
     plural: apiproducts
     singular: apiproduct
     shortNames:
-    - apip
+      - apip
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            required:
-            - displayName
-            - targetRef
-            properties:
-              displayName:
-                type: string
-                description: human-readable name for the api product
-              description:
-                type: string
-                description: detailed description of the api product
-              version:
-                type: string
-                description: api version (e.g. v1, v2)
-              approvalMode:
-                type: string
-                enum: [automatic, manual]
-                default: manual
-                description: whether access requests are auto-approved or require manual review
-              tags:
-                type: array
-                description: tags for categorisation and search
-                items:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - displayName
+                - targetRef
+              properties:
+                displayName:
                   type: string
-              targetRef:
-                type: object
-                description: reference to the httproute that this api product represents
-                required:
-                - group
-                - kind
-                - name
-                properties:
-                  group:
+                  description: human-readable name for the api product
+                description:
+                  type: string
+                  description: detailed description of the api product
+                version:
+                  type: string
+                  description: api version (e.g. v1, v2)
+                approvalMode:
+                  type: string
+                  enum: [automatic, manual]
+                  default: manual
+                  description: whether access requests are auto-approved or require manual review
+                tags:
+                  type: array
+                  description: tags for categorisation and search
+                  items:
                     type: string
-                    default: gateway.networking.k8s.io
-                  kind:
-                    type: string
-                    default: HTTPRoute
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                    description: namespace of httproute (defaults to apiproduct namespace)
-              plans:
-                type: array
-                description: discovered plan information from planpolicies attached to httproute (populated by controller)
-                items:
+                targetRef:
                   type: object
+                  description: reference to the httproute that this api product represents
                   required:
-                  - tier
+                    - group
+                    - kind
+                    - name
                   properties:
-                    tier:
+                    group:
                       type: string
-                      description: plan tier name (can be any custom name)
-                    description:
+                      default: gateway.networking.k8s.io
+                    kind:
                       type: string
-                      description: human-readable description of this plan
-                    limits:
-                      type: object
-                      description: rate limit summary for this plan
-                      properties:
-                        daily:
-                          type: integer
-                          description: daily request limit
-                        weekly:
-                          type: integer
-                          description: weekly request limit
-                        monthly:
-                          type: integer
-                          description: monthly request limit
-                        custom:
-                          type: array
-                          description: custom rate limits
-                          items:
-                            type: object
-                            required:
-                            - limit
-                            - window
-                            properties:
-                              limit:
-                                type: integer
-                              window:
-                                type: string
-                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-              documentation:
-                type: object
-                description: api documentation links
-                properties:
-                  openAPISpec:
-                    type: string
-                    description: url to openapi specification (json/yaml)
-                  swaggerUI:
-                    type: string
-                    description: url to swagger ui or similar interactive docs
-                  docsURL:
-                    type: string
-                    description: url to general documentation
-                  gitRepository:
-                    type: string
-                    description: url to git repository (shown as view source in backstage)
-                  techdocsRef:
-                    type: string
-                    description: techdocs reference (e.g. url:https://github.com/org/repo or dir:. for local docs)
-              contact:
-                type: object
-                description: contact information for api owners
-                properties:
-                  team:
-                    type: string
-                    description: team name
-                  email:
-                    type: string
-                    format: email
-                    description: contact email
-                  slack:
-                    type: string
-                    description: slack channel (e.g. #api-support)
-                  url:
-                    type: string
-                    description: url to team page or support portal
-              publishStatus:
-                type: string
-                enum: [ Draft, Published ]
-                default: Draft
-                description: controls whether the api product appears in the backstage catalog (Draft = hidden, Published = visible)
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  required:
-                  - type
-                  - status
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-                      enum: ["True", "False", "Unknown"]
-                    reason:
-                      type: string
-                    message:
-                      type: string
-                    lastTransitionTime:
-                      type: string
-                      format: date-time
-              httpRouteStatus:
-                type: string
-                description: status of referenced httproute
-              discoveredPlans:
-                type: array
-                description: list of planpolicies discovered from httproute
-                items:
-                  type: object
-                  properties:
+                      default: HTTPRoute
                     name:
                       type: string
                     namespace:
                       type: string
-              lastSyncTime:
-                type: string
-                format: date-time
-                description: last time plan data was synced from httproute
-    additionalPrinterColumns:
-    - name: Display Name
-      type: string
-      jsonPath: .spec.displayName
-    - name: Version
-      type: string
-      jsonPath: .spec.version
-    - name: HTTPRoute
-      type: string
-      jsonPath: ".spec.targetRef.name"
-      description: Referenced HTTPRoute name
-    - name: Age
-      type: date
-      jsonPath: .metadata.creationTimestamp
-    subresources:
-      status: {}
+                      description: namespace of httproute (defaults to apiproduct namespace)
+                plans:
+                  type: array
+                  description: discovered plan information from planpolicies attached to httproute (populated by controller)
+                  items:
+                    type: object
+                    required:
+                      - tier
+                    properties:
+                      tier:
+                        type: string
+                        description: plan tier name (can be any custom name)
+                      description:
+                        type: string
+                        description: human-readable description of this plan
+                      limits:
+                        type: object
+                        description: rate limit summary for this plan
+                        properties:
+                          daily:
+                            type: integer
+                            description: daily request limit
+                          weekly:
+                            type: integer
+                            description: weekly request limit
+                          monthly:
+                            type: integer
+                            description: monthly request limit
+                          custom:
+                            type: array
+                            description: custom rate limits
+                            items:
+                              type: object
+                              required:
+                                - limit
+                                - window
+                              properties:
+                                limit:
+                                  type: integer
+                                window:
+                                  type: string
+                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                documentation:
+                  type: object
+                  description: api documentation links
+                  properties:
+                    openAPISpec:
+                      type: string
+                      description: url to openapi specification (json/yaml)
+                    swaggerUI:
+                      type: string
+                      description: url to swagger ui or similar interactive docs
+                    docsURL:
+                      type: string
+                      description: url to general documentation
+                    gitRepository:
+                      type: string
+                      description: url to git repository (shown as view source in backstage)
+                    techdocsRef:
+                      type: string
+                      description: techdocs reference (e.g. url:https://github.com/org/repo or dir:. for local docs)
+                contact:
+                  type: object
+                  description: contact information for api owners
+                  properties:
+                    team:
+                      type: string
+                      description: team name
+                    email:
+                      type: string
+                      format: email
+                      description: contact email
+                    slack:
+                      type: string
+                      description: slack channel (e.g. #api-support)
+                    url:
+                      type: string
+                      description: url to team page or support portal
+                publishStatus:
+                  type: string
+                  enum: [Draft, Published]
+                  default: Draft
+                  description: controls whether the api product appears in the backstage catalog (Draft = hidden, Published = visible)
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                openapi:
+                  type: object
+                  properties:
+                    raw:
+                      type: string
+                      description: status of referenced httproute
+                    lastSyncTime:
+                      type: string
+                      format: date-time
+                httpRouteStatus:
+                  type: string
+                  description: status of referenced httproute
+                discoveredPlans:
+                  type: array
+                  description: list of planpolicies discovered from httproute
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                lastSyncTime:
+                  type: string
+                  format: date-time
+                  description: last time plan data was synced from httproute
+      additionalPrinterColumns:
+        - name: Display Name
+          type: string
+          jsonPath: .spec.displayName
+        - name: Version
+          type: string
+          jsonPath: .spec.version
+        - name: HTTPRoute
+          type: string
+          jsonPath: ".spec.targetRef.name"
+          description: Referenced HTTPRoute name
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}

--- a/kuadrant-dev-setup/demo/toystore-demo.yaml
+++ b/kuadrant-dev-setup/demo/toystore-demo.yaml
@@ -211,3 +211,4 @@ spec:
     email: api-owners@example.com
     slack: "#api-support"
 ---
+

--- a/kuadrant-dev-setup/demo/toystore-status.yaml
+++ b/kuadrant-dev-setup/demo/toystore-status.yaml
@@ -1,0 +1,184 @@
+status:
+  openapi:
+    lastSyncTime: "2025-11-19T10:16:57Z"
+    raw: |
+      {
+        "openapi": "3.1.0",
+        "info": {
+          "version": "4.3.7",
+          "title": "Swagger toystore",
+          "license": {
+            "name": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        },
+        "servers": [
+          {
+            "url": "http://toystore.example.com/v1"
+          }
+        ],
+        "paths": {
+          "/toys": {
+            "get": {
+              "summary": "List all toys",
+              "operationId": "listToys",
+              "tags": [
+                "toys"
+              ],
+              "parameters": [
+                {
+                  "name": "limit",
+                  "in": "query",
+                  "description": "How many items to return at one time (max 100)",
+                  "required": false,
+                  "schema": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "A paged array of toys",
+                  "headers": {
+                    "x-next": {
+                      "description": "A link to the next page of responses",
+                      "schema": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/Toys"
+                      }
+                    }
+                  }
+                },
+                "default": {
+                  "description": "unexpected error",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/Error"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "post": {
+              "summary": "Create a toy",
+              "operationId": "createToys",
+              "tags": [
+                "toys"
+              ],
+              "responses": {
+                "201": {
+                  "description": "Null response"
+                },
+                "default": {
+                  "description": "unexpected error",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "/toys/{toyId}": {
+            "get": {
+              "summary": "Info for a specific toy",
+              "operationId": "showToyById",
+              "tags": [
+                "toys"
+              ],
+              "parameters": [
+                {
+                  "name": "toyId",
+                  "in": "path",
+                  "required": true,
+                  "description": "The id of the toy to retrieve",
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Expected response to a valid request",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/Toy"
+                      }
+                    }
+                  }
+                },
+                "default": {
+                  "description": "unexpected error",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "components": {
+          "schemas": {
+            "Toy": {
+              "type": "object",
+              "required": [
+                "id",
+                "name"
+              ],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            },
+            "Toys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Toy"
+              }
+            },
+            "Error": {
+              "type": "object",
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+---
+

--- a/plugins/kuadrant-backend/src/providers/APIProductEntityProvider.ts
+++ b/plugins/kuadrant-backend/src/providers/APIProductEntityProvider.ts
@@ -42,6 +42,12 @@ interface APIProduct {
       slack?: string;
     };
   };
+  status: {
+    openapi?: {
+      raw?: string;
+      lastSyncTime?: string;
+    };
+  }
 }
 
 export class APIProductEntityProvider implements EntityProvider {
@@ -143,7 +149,7 @@ export class APIProductEntityProvider implements EntityProvider {
     const tags = product.spec.tags || [];
 
     // OpenAPI spec URL
-    const definition = product.spec.documentation?.openAPISpec ? `$openapi: ${product.spec.documentation.openAPISpec}`
+    const definition = product.status.openapi?.raw ? `${product.status.openapi.raw}`
       : `# no openapi spec configured
       openapi: 3.0.0
       info:


### PR DESCRIPTION
### What
Fixes #55 

Problem: The _$openapi_ placeholder syntax supported by https://www.npmjs.com/package/@backstage/plugin-catalog-backend-module-openapi doesn't work when entities are submitted via entity providers. It only works when entities are loaded from YAML files through the catalog processor chain. It works when there is a resource like the following in the catalog-entities:

```yaml
apiVersion: backstage.io/v1alpha1
kind: API
metadata:
  name: petstore
  title: Petstore
  description: |
    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
    Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
    You can now help us improve the API whether it's by making changes to the definition itself or to the code.
    That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
  links:
    - title: Petstore
      url: https://petstore3.swagger.io/
    - title: Petstore API
      url: https://petstore3.swagger.io/api/v3/openapi.json
spec:
  type: openapi
  system: janus-idp
  owner: janus-authors
  lifecycle: production
  definition:
    $openapi: https://github.com/OAI/learn.openapis.org/blob/main/examples/v3.0/petstore.yaml
```

But we cannot rely on that _$openapi_ placeholder when building dynamically the API entities from the APIProduct resources. 

Solution: the developer-portal-controller will fetch the OpenAPI spec directly and populate status with the openapi content. The entity provider will then populate spec.definition with the actual content. This work has been captured in https://github.com/Kuadrant/developer-portal-controller/issues/9. 

The APIProduct CRD has new data in `status` regarding openapi

```yaml
kind: APIProduct
metadata:
  name: toystore-api
  namespace: toystore
spec:
  approvalMode: manual
  description: simple toy store api for demonstration
  displayName: Toystore API
  documentation:
    docsURL: http://api.toystore.com/docs
    openAPISpec: http://api.toystore.com/openapi.json
  publishStatus: Published
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
    namespace: toystore
  version: v1
status:
  openapi:
    lastSyncTime: "2025-11-19T10:16:57Z"
    raw: |
      {
        "openapi": "3.1.0",
        "info": {
          "version": "4.3.7",
          "title": "Swagger toystore",
          "license": {
            "name": "MIT",
            "url": "https://opensource.org/licenses/MIT"
          }
        }
```

The entity provider `APIProductEntityProvider` will populate 

### Verification Steps

```bash
cd kuadrant-dev-setup
make kind-create
cd ..
yarn dev
```

**As owner1:**
- Log in as `owner1@kuadrant.local` / `owner1`
- Navigate to `/api-docs`
- Select existing "Toystore API"
- Open the "Definition" tab
- Verify the openapi UI has been rendered.