### PR TITLE
add draft api product checker

### DIFF
--- a/plugins/kuadrant/src/components/KuadrantPage/KuadrantPage.tsx
+++ b/plugins/kuadrant/src/components/KuadrantPage/KuadrantPage.tsx
@@ -183,11 +183,25 @@ export const ResourceList = () => {
     {
       title: 'Name',
       field: 'name',
-      render: (row: any) => (
-        <Link to={`/catalog/default/api/${row.metadata.name}/api-product`}>
-          <strong>{row.spec?.displayName || row.metadata.name}</strong>
-        </Link>
-      ),
+      render: (row: any) => {
+        const publishStatus = row.spec?.publishStatus;
+        const isPublished = publishStatus === 'Published';
+        const displayName = row.spec?.displayName ?? row.metadata.name;
+
+        if (isPublished) {
+          return (
+            <Link to={`/catalog/default/api/${row.metadata.name}/api-product`}>
+              <strong>{displayName}</strong>
+            </Link>
+          );
+        }
+
+        return (
+          <span className="text-muted">
+        <strong>{displayName}</strong>
+      </span>
+        );
+      },
     },
     {
       title: 'Resource Name',
@@ -254,7 +268,7 @@ export const ResourceList = () => {
               <EditIcon fontSize="small" />
             </IconButton>
           )}
-          
+
           {canDeleteApiProduct && (
             <IconButton
               size="small"


### PR DESCRIPTION
closes #84 

Verification:

- Install dependencies:

`yarn install`

- Create kind cluster with Kuadrant

```
cd kuadrant-dev-setup
make kind-create (very important make it again to apply the changes)
cd ..
```

- Start development server with hot reload

`yarn dev`

- Open kuadrant page and try to click name of some api product with draft status
- link should don't work
<img width="1196" height="687" alt="Screenshot 2025-11-24 at 11 54 00" src="https://github.com/user-attachments/assets/77b5f9a4-b615-4183-ad6d-cc4711242b56" />
