### PR TITLE
ApprovalQueueCard: Check content type

### DIFF
--- a/plugins/kuadrant/src/components/ApprovalQueueCard/ApprovalQueueCard.tsx
+++ b/plugins/kuadrant/src/components/ApprovalQueueCard/ApprovalQueueCard.tsx
@@ -249,7 +249,8 @@ export const ApprovalQueueCard = () => {
     if (!contentType?.includes('application/json')) {
       console.error('ApprovalQueueCard: received non-json response');
       alertApi.post({
-        message: 'Unexpected server response. Please contact support.',
+        message: 'Unexpected content-type from the server response. Please contact support.',
+        display: 'transient',
         severity: 'warning'
       });
       return { pending: [] as APIKeyRequest[], approved: [] as APIKeyRequest[], rejected: [] as APIKeyRequest[], reviewedBy, ownedApiProducts: new Set<string>() };


### PR DESCRIPTION
### What

ApprovalQueueCard.tsx checks content-type but returns empty arrays silently, hiding potential backend issues.

For unexpected responses, show warning instead of failing silently

### Verification Steps

Let's patch backend to return unexpected response when it's been asked to return apikeyrequests.
```
patch -p1 -N <<EOF
diff --git a/plugins/kuadrant-backend/src/router.ts b/plugins/kuadrant-backend/src/router.ts
index 70993a30..32fe9686 100644
--- a/plugins/kuadrant-backend/src/router.ts
+++ b/plugins/kuadrant-backend/src/router.ts
@@ -779,7 +779,7 @@ export async function createRouter({
         });
       }
 
-      res.json({ items: filteredItems });
+      res.send('this is a test');
     } catch (error) {
       console.error('error fetching api key requests:', error);
       if (error instanceof NotAllowedError) {
EOF
```

Run the environment

```bash
cd kuadrant-dev-setup
make kind-create
cd ..
yarn dev
```

####  Successfully submit api access request
- Log in as `owner1@kuadrant.local` / `owner1`
- Navigate to `/kuadrant`
- Verify the warning, yellow feedback, toast confirms there was an issue with server response related to the content-type.

<img width="768" height="174" alt="Screenshot from 2025-12-01 10-12-40" src="https://github.com/user-attachments/assets/7157e9d8-7894-4521-86f3-74a78c423490" />
