### PR TITLE
use NPM trusted publisher instead

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,15 +83,11 @@ jobs:
         run: |
           cd plugins/kuadrant
           npm publish --provenance --access public --tag ${{ steps.version.outputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_GIT }}
 
       - name: Publish backend
         run: |
           cd plugins/kuadrant-backend
           npm publish --provenance --access public --tag ${{ steps.version.outputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_GIT }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
Shifted to NPMJS trusted publishing, rather than using existing NPM_TOKEN_GIT env var, and all the mess involved with keeping secrets working.

Now enabled for both:

https://www.npmjs.com/package/@kuadrant/kuadrant-backstage-plugin-frontend/
https://www.npmjs.com/package/@kuadrant/kuadrant-backstage-plugin-backend/

More info:

https://docs.npmjs.com/trusted-publishers