### PR TITLE
adding alert to api overview if status conditions are not ready

### DIFF
--- a/packages/app/src/components/catalog/EntityPage/OverviewTabContent.tsx
+++ b/packages/app/src/components/catalog/EntityPage/OverviewTabContent.tsx
@@ -26,7 +26,10 @@ import {
   EntityUserProfileCard,
 } from '@backstage/plugin-org';
 
-import { EntityKuadrantApiAccessCard } from '@kuadrant/kuadrant-backstage-plugin-frontend';
+import {
+  EntityKuadrantApiAccessCard,
+  EntityKuadrantApiProductOpenApiAlert,
+} from '@kuadrant/kuadrant-backstage-plugin-frontend';
 
 import Grid from '../Grid';
 import { hasLinks } from '../utils';
@@ -178,6 +181,14 @@ export const OverviewTabContent = () => (
           }}
         >
           <EntityCatalogGraphCard variant="gridItem" height={400} />
+        </Grid>
+        <Grid
+          item
+          sx={{
+            gridColumn: '1 / -1',
+          }}
+        >
+          <EntityKuadrantApiProductOpenApiAlert />
         </Grid>
         <Grid
           item

--- a/plugins/kuadrant/src/components/ApiProductOpenApiAlert/ApiProductOpenApiAlert.tsx
+++ b/plugins/kuadrant/src/components/ApiProductOpenApiAlert/ApiProductOpenApiAlert.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { useEntity } from "@backstage/plugin-catalog-react";
+import { useApi, configApiRef, fetchApiRef } from "@backstage/core-plugin-api";
+import { Link } from "@backstage/core-components";
+import { Box, Typography } from "@material-ui/core";
+import { Alert } from "@material-ui/lab";
+import useAsync from "react-use/lib/useAsync";
+
+// Displays alerts for OpenAPI spec issues.
+export const ApiProductOpenApiAlert = () => {
+  const { entity } = useEntity();
+  const config = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const backendUrl = config.getString("backend.baseUrl");
+
+  // Get APIProduct reference from entity annotations
+  const namespace = entity.metadata.annotations?.["kuadrant.io/namespace"];
+  const apiProductName =
+    entity.metadata.annotations?.["kuadrant.io/apiproduct"];
+
+  // Fetch the full APIProduct resource to check status conditions
+    const {value: apiProduct,loading,error,} = useAsync(async () => {
+    if (!namespace || !apiProductName) {
+      return null;
+    }
+
+    const response = await fetchApi.fetch(
+      `${backendUrl}/api/kuadrant/apiproducts/${namespace}/${apiProductName}`,
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return await response.json();
+  }, [backendUrl, fetchApi, namespace, apiProductName]);
+
+  // Don't render anything if data is missing or still loading
+  if (!namespace || !apiProductName || loading || error || !apiProduct) {
+    return null;
+  }
+
+  const { spec, status } = apiProduct;
+
+  const openAPICondition = status?.conditions?.find(
+    (c: any) => c.type === "OpenAPISpecReady" && c.status === "False",
+  );
+
+  if (!openAPICondition) {
+    return null;
+  }
+
+  return (
+    <Box mb={2}>
+      <Alert severity="warning">
+        <Typography variant="body2" gutterBottom>
+          <strong>OpenAPI Spec Issue</strong>
+        </Typography>
+        <Typography variant="body2" gutterBottom>
+          {openAPICondition.message}
+        </Typography>
+        {spec.documentation?.openAPISpecURL && (
+          <Typography variant="body2">
+            Spec URL:{" "}
+            <Link to={spec.documentation.openAPISpecURL} target="_blank">
+              {spec.documentation.openAPISpecURL}
+            </Link>
+          </Typography>
+        )}
+      </Alert>
+    </Box>
+  );
+};

--- a/plugins/kuadrant/src/components/ApiProductOpenApiAlert/index.ts
+++ b/plugins/kuadrant/src/components/ApiProductOpenApiAlert/index.ts
@@ -1,0 +1,1 @@
+export { ApiProductOpenApiAlert } from './ApiProductOpenApiAlert';

--- a/plugins/kuadrant/src/index.ts
+++ b/plugins/kuadrant/src/index.ts
@@ -9,6 +9,7 @@ export {
   EntityKuadrantApiKeysContent,
   EntityKuadrantApiProductInfoContent,
   EntityKuadrantApiApprovalTab,
+  EntityKuadrantApiProductOpenApiAlert,
   KuadrantApprovalQueueCard,
   PlanPolicyDetailPage,
 } from './plugin';

--- a/plugins/kuadrant/src/plugin.ts
+++ b/plugins/kuadrant/src/plugin.ts
@@ -120,3 +120,13 @@ export const EntityKuadrantApiApprovalTab = kuadrantPlugin.provide(
     },
   }),
 );
+
+export const EntityKuadrantApiProductOpenApiAlert = kuadrantPlugin.provide(
+  createComponentExtension({
+    name: 'EntityKuadrantApiProductOpenApiAlert',
+    component: {
+      lazy: () =>
+        import('./components/ApiProductOpenApiAlert').then(m => m.ApiProductOpenApiAlert),
+    },
+  }),
+);

--- a/plugins/kuadrant/src/types/api-management.ts
+++ b/plugins/kuadrant/src/types/api-management.ts
@@ -12,6 +12,24 @@ export interface PlanLimits {
   }>;
 }
 
+// Status condition types for Kubernetes resources
+export type OpenAPISpecConditionReason =
+  | 'SpecFetched'
+  | 'SpecSizeTooLarge'
+  | 'FetchFailed';
+
+export type StatusConditionType =
+  | 'OpenAPISpecReady'
+  | string; // Allow other condition types
+
+export interface StatusCondition {
+  type: StatusConditionType;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: OpenAPISpecConditionReason | string;
+  message?: string;
+  lastTransitionTime?: string;
+}
+
 export interface APIKeySpec {
   apiProductRef: {
     name: string;
@@ -35,13 +53,7 @@ export interface APIKeyStatus {
     key: string;
   };
   canReadSecret?: boolean;
-  conditions?: Array<{
-    type: string;
-    status: 'True' | 'False' | 'Unknown';
-    reason?: string;
-    message?: string;
-    lastTransitionTime?: string;
-  }>;
+  conditions?: StatusCondition[];
 }
 
 export interface APIKey {
@@ -98,13 +110,7 @@ export interface APIProductStatus {
     raw: string;
     lastSyncTime: string;
   };
-  conditions?: Array<{
-    type: string;
-    status: 'True' | 'False' | 'Unknown';
-    reason?: string;
-    message?: string;
-    lastTransitionTime?: string;
-  }>;
+  conditions?: StatusCondition[];
 }
 
 export interface APIProduct {
@@ -147,12 +153,6 @@ export interface PlanPolicy {
     plans: PlanPolicyPlan[];
   };
   status?: {
-    conditions?: Array<{
-      type: string;
-      status: 'True' | 'False' | 'Unknown';
-      reason?: string;
-      message?: string;
-      lastTransitionTime?: string;
-    }>;
+    conditions?: StatusCondition[];
   };
 }


### PR DESCRIPTION
Adding an alert box if the API product OpenAPI spec status contains errors

<img width="2289" height="1096" alt="Screenshot 2026-01-19 at 17 18 20" src="https://github.com/user-attachments/assets/a012f8f0-f149-49dc-97c7-d0cba7afef2b" />

## Verification
Create a apiproduct cr that has a issue with the openapispec. You should see a alert like in the screenshot above with the error message from the status. Note you will need the controller to be running this version https://github.com/Kuadrant/developer-portal-controller/pull/24
