### PR TITLE
remove the backstage.io/expose annotation req

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,9 +16,7 @@ The backend plugin exposes REST API endpoints at `/api/kuadrant/*`. All endpoint
 
 | Method | Endpoint | Description | Permission |
 |--------|----------|-------------|------------|
-| GET | `/api/kuadrant/httproutes` | List HTTPRoutes with `backstage.io/expose: "true"` annotation | `kuadrant.apiproduct.list` |
-
-HTTPRoutes must have the `backstage.io/expose: "true"` annotation to appear in the list. This is set by platform engineers when exposing routes for API publishing.
+| GET | `/api/kuadrant/httproutes` | List all HTTPRoutes | `kuadrant.apiproduct.list` |
 
 ## PlanPolicy Endpoints
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,7 +78,7 @@ kubectl -n getting-started-tutorial wait --timeout=120s --for=condition=Availabl
 
 ### Step 2: Create the Gateway and HTTPRoute
 
-Create a Gateway and expose the API via an HTTPRoute. The `backstage.io/expose: "true"` annotation makes the route available for publishing in the developer portal.
+Create a Gateway and expose the API via an HTTPRoute.
 
 ```bash
 kubectl apply -f - <<EOF
@@ -102,8 +102,6 @@ kind: HTTPRoute
 metadata:
   name: getting-started-toystore
   namespace: getting-started-tutorial
-  annotations:
-    backstage.io/expose: "true"
 spec:
   parentRefs:
     - name: getting-started-gateway

--- a/docs/kuadrant-resources.md
+++ b/docs/kuadrant-resources.md
@@ -37,9 +37,8 @@ See [`plugins/kuadrant-backend/src/router.ts`](../plugins/kuadrant-backend/src/r
 - Platform Engineers set up infrastructure on-cluster **first**:
   1. Create PlanPolicy with rate limit tiers
   2. Apply PlanPolicy to HTTPRoute via `targetRef`
-  3. Annotate HTTPRoute to expose in Backstage (`backstage.io/expose: "true"`)
 - API Owner workflow in Backstage:
-  1. Browse list of available HTTPRoutes (filtered by annotation)
+  1. Browse list of available HTTPRoutes
   2. Select existing HTTPRoute to publish
   3. Add catalog metadata (display name, description, docs, tags)
   4. APIProduct is created with `spec.targetRef` pointing to HTTPRoute

--- a/docs/rbac-permissions.md
+++ b/docs/rbac-permissions.md
@@ -199,7 +199,6 @@ The Kuadrant plugin defines four personas with distinct responsibilities and per
 **Responsibilities**:
 - Manages cluster infrastructure (Gateways, HTTPRoutes, PlanPolicies)
 - Creates PlanPolicy resources with rate limit tiers
-- Annotates HTTPRoutes with `backstage.io/expose: "true"` to make them available for publishing
 - Coordinates with API Admins and API Owners when changing rate limits
 - Does not typically manage individual API Products (delegated to API Admins/Owners)
 
@@ -219,7 +218,7 @@ Comprehensive view of what each persona can and cannot do:
 
 | Persona | Can Do | Cannot Do |
 |---------|--------|-----------|
-| **Platform Engineer** | • Manage Kuadrant infrastructure (Gateways, HTTPRoutes)<br/>• Create/update/delete PlanPolicy resources<br/>• Annotate HTTPRoutes with `backstage.io/expose: "true"`<br/>• Manage RBAC policies and permissions<br/>• Configure platform-wide settings<br/>• Full cluster admin access for platform management | • Typically does not manage day-to-day API Products (delegates to API Admin/Owner)<br/>• Should coordinate with API Admins and API Owners before changing rate limits |
+| **Platform Engineer** | • Manage Kuadrant infrastructure (Gateways, HTTPRoutes)<br/>• Create/update/delete PlanPolicy resources<br/>• Manage RBAC policies and permissions<br/>• Configure platform-wide settings<br/>• Full cluster admin access for platform management | • Typically does not manage day-to-day API Products (delegates to API Admin/Owner)<br/>• Should coordinate with API Admins and API Owners before changing rate limits |
 | **API Admin** | • Read all APIProducts<br/>• Create/update/delete any APIProduct<br/>• Approve/reject any API key requests<br/>• Manage all API keys (read/delete)<br/>• View all APIKeys<br/>• Troubleshoot on behalf of API Owners<br/>• All `.all` scoped permissions | • Cannot create/update/delete PlanPolicy<br/>• Cannot modify platform infrastructure (HTTPRoutes, Gateways) |
 | **API Owner** | • Read/list HTTPRoutes (to publish APIs)<br/>• Create/update/delete own APIProducts<br/>• Read all APIProducts<br/>• Approve/reject API key requests for own APIs<br/>• Delete API key requests for own APIs<br/>• Manage own API documentation<br/>• View/manage API keys for own APIs | • Cannot create/update PlanPolicy<br/>• Cannot modify platform infrastructure<br/>• Cannot approve requests for other owners' APIs<br/>• Cannot update/delete other owners' APIProducts |
 | **API Consumer** | • Read/list APIProduct<br/>• Create APIKey<br/>• Read/update/delete own APIKeys<br/>• View own request status<br/>• Manage own API keys<br/>• Use APIs within rate limit quotas | • Cannot approve requests<br/>• Cannot view others' requests<br/>• Cannot create or publish APIs<br/>• Cannot modify rate limits |

--- a/kuadrant-dev-setup/demo/gamestore-demo.yaml
+++ b/kuadrant-dev-setup/demo/gamestore-demo.yaml
@@ -66,8 +66,6 @@ kind: HTTPRoute
 metadata:
   name: gamestore
   namespace: gamestore
-  annotations:
-    backstage.io/expose: "true"
 spec:
   parentRefs:
     - name: external
@@ -134,8 +132,6 @@ kind: HTTPRoute
 metadata:
   name: gamestore-admin
   namespace: gamestore
-  annotations:
-    backstage.io/expose: "true"
 spec:
   parentRefs:
     - name: external

--- a/kuadrant-dev-setup/demo/toystore-demo.yaml
+++ b/kuadrant-dev-setup/demo/toystore-demo.yaml
@@ -71,8 +71,6 @@ kind: HTTPRoute
 metadata:
   name: toystore
   namespace: toystore
-  annotations:
-    backstage.io/expose: "true"
 spec:
   parentRefs:
     - name: external

--- a/plugins/kuadrant/src/components/CreateAPIProductDialog/CreateAPIProductDialog.tsx
+++ b/plugins/kuadrant/src/components/CreateAPIProductDialog/CreateAPIProductDialog.tsx
@@ -87,10 +87,7 @@ export const CreateAPIProductDialog = ({ open, onClose, onSuccess }: CreateAPIPr
   } = useAsync(async () => {
     const response = await fetchApi.fetch(`${backendUrl}/api/kuadrant/httproutes`);
     const data = await response.json();
-    // filter to only show httproutes annotated for backstage exposure
-    return (data.items || []).filter((route: any) =>
-      route.metadata.annotations?.['backstage.io/expose'] === 'true'
-    );
+    return data.items || [];
   }, [backendUrl, fetchApi, open, httpRoutesRetry]);
 
   // load planpolicies with full details to show associated plans
@@ -470,7 +467,7 @@ export const CreateAPIProductDialog = ({ open, onClose, onSuccess }: CreateAPIPr
               helperText={
                 httpRoutesError
                   ? "Unable to load HTTPRoutes. Please retry."
-                  : "Select an HTTPRoute. Eg.backstage.io/expose:true. API product will be created in the same namespace."
+                  : "Select an HTTPRoute. APIProduct will be created in the same namespace."
               }
               error={!!httpRoutesError}
               disabled={httpRoutesLoading || creating || !!httpRoutesError}


### PR DESCRIPTION
Removed the `backstage.io/expose` annotation requirement from HTTPRoutes. It seemed like a good idea earlier on in the PoC, but while reviewing earlier I couldn't help but think that it was complexity we don't really need.