### PR TITLE
fixup: menu icon for api key approvals

### DIFF
--- a/packages/app/src/components/DynamicRoot/CommonIcons.tsx
+++ b/packages/app/src/components/DynamicRoot/CommonIcons.tsx
@@ -1,6 +1,7 @@
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
 import AddCircle from '@mui/icons-material/AddCircleOutline';
 import Api from '@mui/icons-material/ApiOutlined';
+import Approval from '@mui/icons-material/ApprovalOutlined';
 import Bookmarks from '@mui/icons-material/BookmarksOutlined';
 import Business from '@mui/icons-material/BusinessOutlined';
 import Category from '@mui/icons-material/CategoryOutlined';
@@ -68,6 +69,7 @@ const CommonIcons: {
   admin: AdminIcon,
   key: Key,
   api: Api,
+  approval: Approval,
   kuadrant: Kuadrant,
 };
 


### PR DESCRIPTION
Small PR to fixup icon for this menu item.


Before (broken):

<img width="209" height="197" alt="Screenshot 2026-02-16 at 11 12 12" src="https://github.com/user-attachments/assets/eabb2424-8c39-42cd-8f14-73e6371fa9eb" />

After (rubber stamp icon):
<img width="202" height="260" alt="Screenshot 2026-02-16 at 11 13 41" src="https://github.com/user-attachments/assets/20e0fd71-7f9f-433b-89a5-3fc66cc2b215" />


