### PR TITLE
ApiProductDetailPage: policies tab show discovered policies

### DIFF
--- a/plugins/kuadrant/src/components/ApiProductPolicies/ApiProductPolicies.tsx
+++ b/plugins/kuadrant/src/components/ApiProductPolicies/ApiProductPolicies.tsx
@@ -48,10 +48,8 @@ export const ApiProductPolicies: React.FC<ApiProductPoliciesProps> = ({
   return (
     <Box
       mt={includeTopMargin ? 1 : 0}
-      p={2}
+      p={0}
       bgcolor={theme.palette.background.default}
-      borderRadius={1}
-      border={`1px solid ${theme.palette.divider}`}
     >
       <Grid container spacing={2}>
         {/* planpolicy chip shown when either plan exist or ratelimitpolicy does not exist*/}


### PR DESCRIPTION
### What

TL;DR: bring `ApiProductPolicies`  widget introduced in #236 to show related policies when creating (or editing) an APIProduct to the `policies` tab of the `ApiProductDetailPage`. 

Changes:

* Policies tab always visible.
* ApiProductDetailPage.tsx _policies_ tab showing  ApiProductPolicies widget instead of custom view. 
* The new view is defined in ApiProductPolicies widget. From https://github.com/Kuadrant/kuadrant-backstage-plugin/pull/236
  * Always shows AuthPolicy chip indicating existence and name/namespace 
  * When plan policy not available and ratelimitpolicy is available, then shows RateLimitPolicy chip indicating existence. Note that if both exist, plan policy is being shown shadowing the rate limit policy.
and name/namespace
* ApiProductPolicies widget requires some props, added the logic to compute props. Downside is that rate limit policies are loaded even if _policies_ tab is not clicked.  
* Removed _ApiProductPolicies_ widget's border. Trying to keep consistent UX across all tabs of the ApiProductDetailPage. For the create/edit APIProduct form, border-less is better (just a personal opinion here). 

Snapshot of an APIProduct protected with a plan policy

<img width="945" height="498" alt="Screenshot 2026-02-26 at 17-35-26 Analytics API (Admin) Red Hat Developer Hub" src="https://github.com/user-attachments/assets/f95a1643-b14e-4fcd-9afc-70ba4f6cfcfc" />

Snapshot of an APIProduct protected with a rate limit policy

<img width="935" height="360" alt="Screenshot 2026-02-26 at 17-35-10 Gamestore API Red Hat Developer Hub" src="https://github.com/user-attachments/assets/3ae984ce-6fec-4e6f-aa18-c9ae768264fb" />

### Verification steps

* Run dev environment
```
# Create kind cluster with Kuadrant
cd kuadrant-dev-setup
make kind-create
cd ..

# Start development server with hot reload
yarn dev
```

* As owner/admin, select any existing apiproducts and enter the _policies_ tab.  See differences between APIProducts protected with plan policies and those not protected with plan policies. 
* As owner/admin, create a new APIProduct  associated to the `policy-free` HTTPRoute and then select it and navigate to the _policies_ tab. No policies should have been discovered.