### PR TITLE
oinc support for RHDH local testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ For specific topics, refer to these focused guides:
 | [docs/kuadrant-resources.md](docs/kuadrant-resources.md) | CRDs, namespace organisation, approval modes, catalog sync |
 | [docs/ui-patterns.md](docs/ui-patterns.md) | Table patterns, delete dialogs, frontend permissions, sidebar menu config |
 | [docs/ci.md](docs/ci.md) | CI/CD pipelines, release flow, npm publishing, static vs dynamic plugins |
+| [docs/oinc.md](docs/oinc.md) | oinc dev environment, cluster setup, RHDH integration testing |
 
 ## Prerequisites
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -354,7 +354,83 @@ This section covers installing the plugins using [rhdh-local](https://github.com
 
 ### 1. Configure Dynamic Plugins
 
-Copy [Kuadrant backstage dynamic plugins metadata](#dynamic-plugins) into a file named `configs/dynamic-plugins/dynamic-plugins.override.yaml`:
+Add the plugins to `configs/dynamic-plugins/dynamic-plugins.override.yaml`:
+
+```yaml
+includes:
+  - dynamic-plugins.default.yaml
+
+plugins:
+  # RBAC Management UI (bundled with RHDH, just enable it)
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+    disabled: false
+
+  # Kuadrant Backend
+  - package: "@kuadrant/kuadrant-backstage-plugin-backend-dynamic"
+    disabled: false
+    integrity: <sha512-integrity-hash>
+
+  # Kuadrant Frontend
+  - package: "@kuadrant/kuadrant-backstage-plugin-frontend"
+    integrity: <sha512-integrity-hash>
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          internal.plugin-kuadrant:
+            appIcons:
+              - name: kuadrantIcon
+                importName: KuadrantIcon
+            dynamicRoutes:
+              - path: /kuadrant
+                importName: KuadrantPage
+              - path: /kuadrant/api-products
+                importName: ApiProductsPage
+                menuItem:
+                  icon: kuadrantIcon
+                  text: API Products
+              - path: /kuadrant/my-api-keys
+                importName: MyApiKeysPage
+                menuItem:
+                  icon: kuadrantIcon
+                  text: My API Keys
+              - path: /kuadrant/api-key-approval
+                importName: ApiKeyApprovalPage
+                menuItem:
+                  icon: kuadrantIcon
+                  text: API Key Approval
+              - path: /kuadrant/api-products/:namespace/:name
+                importName: ApiProductDetailPage
+              - path: /kuadrant/api-keys/:namespace/:name
+                importName: ApiKeyDetailPage
+            menuItems:
+              kuadrant:
+                icon: kuadrantIcon
+                title: Kuadrant
+              kuadrant.api-products:
+                parent: kuadrant
+              kuadrant.my-api-keys:
+                parent: kuadrant
+              kuadrant.api-key-approval:
+                parent: kuadrant
+            mountPoints:
+              - mountPoint: entity.page.api/cards
+                importName: EntityKuadrantApiKeyManagementTab
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isKind: api
+              - mountPoint: entity.page.api/cards
+                importName: EntityKuadrantApiProductInfoContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isKind: api
+```
 
 To get the integrity hash:
 ```bash
@@ -390,9 +466,14 @@ Add to `configs/app-config/app-config.yaml`:
 permission:
   enabled: true
   rbac:
+    admin:
+      superUsers:
+        - name: <your-admin-user-entity-ref>
     policies-csv-file: /opt/app-root/src/configs/rbac-policy.csv
     policyFileReload: true
 ```
+
+Replace `<your-admin-user-entity-ref>` with the entity ref of your admin user (e.g. `user:default/admin`). This grants full RBAC management permissions.
 
 Create `configs/rbac-policy.csv` with the [RBAC policy content](#rbac-policy).
 

--- a/docs/oinc.md
+++ b/docs/oinc.md
@@ -1,0 +1,141 @@
+# oinc Development Environment
+
+[oinc](https://github.com/jasonmadigan/oinc) (OpenShift in a Container) provides a lightweight OpenShift-compatible cluster for testing the Kuadrant plugins with RHDH dynamic plugins.
+
+This is an alternative to `kuadrant-dev-setup/` (kind cluster + `yarn dev`), not something you run alongside it. Use `kuadrant-dev-setup/` when you're developing plugins and want hot reload. Use oinc when you want to test with stock RHDH and dynamic plugins.
+
+## Prerequisites
+
+- [oinc](https://github.com/jasonmadigan/oinc)
+- kubectl
+- helm
+- npm
+- Docker or Podman
+
+Recommended 8GB+ RAM. The full stack (Istio, Kuadrant, RHDH, PostgreSQL) is heavy.
+
+## Usage
+
+```bash
+# full setup: cluster + RHDH
+yarn oinc
+
+# cluster only: kuadrant, gateway api, istio, metallb, console, demo resources
+yarn oinc:cluster
+
+# RHDH only: install on existing cluster from oinc:cluster
+yarn oinc:rhdh
+
+# teardown
+yarn oinc:teardown
+```
+
+## Modes
+
+### Cluster only (`yarn oinc:cluster`)
+
+Creates an oinc cluster with the full Kuadrant infrastructure stack. Gets you to the **starting point** of the [installation guide](installation.md) -- a cluster with all prerequisites installed, ready for RHDH.
+
+The `oinc create --addons kuadrant` command handles the bulk of the work: Gateway API CRDs, cert-manager, MetalLB, Istio (Sail Operator), Kuadrant Operator, OLM, and the OpenShift Console.
+
+Our setup script then adds:
+- MetalLB IP address pool (auto-detected from the container bridge network)
+- Gateway resource (`kuadrant-ingressgateway` in `gateway-system`)
+- Demo resources from `kuadrant-dev-setup/demo/`
+
+After setup, the OpenShift Console is available at http://localhost:9000.
+
+### RHDH (`yarn oinc:rhdh`)
+
+Installs RHDH on an existing cluster from `oinc:cluster`. Gets you to the **end state** of the [installation guide](installation.md) -- RHDH running with Kuadrant dynamic plugins configured.
+
+Configures: RHDH service account, RBAC policies, dynamic plugins (frontend + backend + RBAC management UI), guest auth, extensions installation UI.
+
+After setup:
+```bash
+kubectl port-forward svc/rhdh-developer-hub 7007:7007 -n rhdh
+# http://localhost:7007/kuadrant
+```
+
+## What oinc provides vs what we add
+
+oinc gives you MicroShift in a container with OLM, OpenShift Console (port 9000), and a ConsolePlugin CRD out of the box. The `--addons kuadrant` flag installs the full Kuadrant stack and all its dependencies via topological dependency resolution.
+
+Our setup scripts add:
+
+**`setup-cluster.sh` adds:**
+
+| Component | Notes |
+|-|-|
+| MetalLB IP pool | Auto-detected from container bridge subnet (.200-.220 range) |
+| Gateway resource | `kuadrant-ingressgateway` in `gateway-system`, istio gatewayClass |
+| Demo resources | APIProducts, PlanPolicies from `kuadrant-dev-setup/demo/` |
+
+**`setup-rhdh.sh` adds:**
+
+| Component | Source | Notes |
+|-|-|-|
+| RHDH (Helm chart) | `rhdh/backstage` | Stock RHDH image with dynamic plugins |
+| Kuadrant plugins | npm packages | Frontend + backend, integrity hashes fetched at setup time |
+| RBAC management UI | Bundled in RHDH image | `backstage-community-plugin-rbac`, just enabled |
+| RHDH service account | `oinc/manifests/rhdh-sa.yaml` | ClusterRole for Kuadrant CRDs |
+| Guest auth + RBAC | ConfigMaps | Guest user gets `api-admin` role for local dev |
+| Extensions UI | app-config + seed file | Enables the plugin management UI in RHDH |
+
+## File structure
+
+```
+oinc/
+  setup.sh              # entry point, dispatches to modes
+  setup-cluster.sh      # oinc create + post-setup (MetalLB pool, Gateway, demos)
+  setup-rhdh.sh         # RHDH installation
+  teardown.sh           # deletes the oinc cluster
+  lib.sh                # shared helpers
+  manifests/
+    rhdh-sa.yaml        # RHDH service account + RBAC
+```
+
+## Differences from `yarn dev`
+
+| | `yarn dev` (kind) | `yarn oinc` (oinc) |
+|-|-|-|
+| Plugins | Static (built into app) | Dynamic (npm packages) |
+| Hot reload | Yes | No (uses published packages) |
+| RHDH image | N/A (standalone Backstage) | Stock RHDH |
+| Use case | Plugin development | Integration testing, installation guide validation |
+
+## Running e2e tests against oinc
+
+With RHDH running and port-forwarded:
+
+```bash
+kubectl port-forward svc/rhdh-developer-hub 7007:7007 -n rhdh
+```
+
+Run the e2e tests with `BASE_URL` pointed at port 7007 (the default is 3000 for `yarn dev`):
+
+```bash
+cd e2e-tests
+BASE_URL=http://localhost:7007 yarn test
+```
+
+## Troubleshooting
+
+Check pod status:
+```bash
+kubectl -n rhdh get pods
+kubectl -n rhdh logs deployment/rhdh-developer-hub
+```
+
+Init container logs (plugin installation):
+```bash
+kubectl -n rhdh logs deployment/rhdh-developer-hub -c install-dynamic-plugins
+```
+
+If RHDH is stuck in init, it's usually downloading plugins. The init container fetches all default RHDH plugins plus the Kuadrant ones from npm.
+
+Cluster status:
+```bash
+oinc status          # endpoints and addon status
+oinc status --watch  # live dashboard
+```

--- a/oinc/lib.sh
+++ b/oinc/lib.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# shared helpers for oinc cluster scripts
+
+log() { echo "==> $*"; }
+
+detect_runtime() {
+  if command -v podman &>/dev/null; then
+    echo "podman"
+  elif command -v docker &>/dev/null; then
+    echo "docker"
+  else
+    echo "error: no container runtime found (need podman or docker)"
+    exit 1
+  fi
+}
+
+check_command() {
+  if ! command -v "$1" &>/dev/null; then
+    echo "error: '$1' not found. $2"
+    exit 1
+  fi
+}

--- a/oinc/manifests/rhdh-sa.yaml
+++ b/oinc/manifests/rhdh-sa.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rhdh
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhdh-kuadrant
+  namespace: rhdh
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhdh-kuadrant-reader
+rules:
+  - apiGroups: ["kuadrant.io"]
+    resources:
+      - authpolicies
+      - ratelimitpolicies
+      - dnspolicies
+      - tlspolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions.kuadrant.io"]
+    resources:
+      - planpolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources:
+      - apiproducts
+      - apikeys
+    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources:
+      - apikeys/status
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources:
+      - gateways
+      - httproutes
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - secrets
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhdh-kuadrant-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhdh-kuadrant-reader
+subjects:
+  - kind: ServiceAccount
+    name: rhdh-kuadrant
+    namespace: rhdh

--- a/oinc/setup-cluster.sh
+++ b/oinc/setup-cluster.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# create an oinc cluster with kuadrant, istio, metallb, and a gateway.
+# applies demo resources for local development.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+check_command oinc "Install from https://github.com/jasonmadigan/oinc"
+check_command kubectl "Install from https://kubernetes.io/docs/tasks/tools/"
+
+RUNTIME=$(detect_runtime)
+
+# --- cluster + addons ---
+
+log "creating oinc cluster with addons..."
+oinc create --addons kuadrant
+
+log "merging kubeconfig..."
+oinc kubeconfig
+
+# --- MetalLB IP pool ---
+
+log "configuring MetalLB IP pool..."
+DOCKER_SUBNET=$(${RUNTIME} network inspect bridge -f '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || echo "172.18.0.0/16")
+POOL_START=$(echo "${DOCKER_SUBNET}" | sed 's|\.[0-9]*/.*|.200|')
+POOL_END=$(echo "${DOCKER_SUBNET}" | sed 's|\.[0-9]*/.*|.220|')
+
+log "MetalLB pool: ${POOL_START}-${POOL_END}"
+kubectl apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: dev-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - ${POOL_START}-${POOL_END}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: dev-l2
+  namespace: metallb-system
+EOF
+
+# --- Gateway ---
+
+log "creating gateway..."
+kubectl create namespace gateway-system 2>/dev/null || true
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kuadrant-ingressgateway
+  namespace: gateway-system
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+EOF
+
+# --- demo resources ---
+
+log "applying demo resources..."
+for f in toystore-demo.yaml gamestore-demo.yaml additional-demos.yaml; do
+  kubectl apply -f "${REPO_DIR}/kuadrant-dev-setup/demo/${f}" || log "warning: failed to apply ${f}"
+done
+
+# --- done ---
+
+echo ""
+echo "============================================"
+echo " oinc cluster ready"
+echo "============================================"
+echo ""
+echo " Cluster has: Gateway API, cert-manager, MetalLB, Istio, Kuadrant, demo resources"
+echo ""
+echo " OpenShift Console:"
+echo "   http://localhost:9000"
+echo ""
+echo " To install RHDH on this cluster:"
+echo "   ./oinc/setup-rhdh.sh"
+echo ""

--- a/oinc/setup-rhdh.sh
+++ b/oinc/setup-rhdh.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# installs and configures RHDH on an existing oinc cluster.
+# expects setup-cluster.sh to have been run first.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+FRONTEND_PKG="@kuadrant/kuadrant-backstage-plugin-frontend"
+BACKEND_PKG="@kuadrant/kuadrant-backstage-plugin-backend-dynamic"
+
+# --- prerequisites ---
+
+check_command kubectl "Install from https://kubernetes.io/docs/tasks/tools/"
+check_command helm "Install from https://helm.sh/docs/intro/install/"
+check_command npm "Install from https://nodejs.org/"
+
+kubectl get crd kuadrants.kuadrant.io &>/dev/null || {
+  log "error: kuadrant CRDs not found. Run setup-cluster.sh first."
+  exit 1
+}
+
+# --- RHDH SA + RBAC ---
+
+log "applying RHDH service account and RBAC..."
+kubectl apply -f "${SCRIPT_DIR}/manifests/rhdh-sa.yaml"
+
+# --- generate SA token ---
+
+SA_TOKEN=$(kubectl create token rhdh-kuadrant -n rhdh --duration=8760h)
+CLUSTER_URL="https://kubernetes.default.svc"
+
+# --- fetch plugin integrity hashes ---
+
+log "fetching plugin integrity hashes..."
+FRONTEND_HASH=$(npm view "${FRONTEND_PKG}" dist.integrity)
+BACKEND_HASH=$(npm view "${BACKEND_PKG}" dist.integrity)
+log "frontend: ${FRONTEND_HASH}"
+log "backend:  ${BACKEND_HASH}"
+
+# --- RHDH configuration ---
+
+log "creating RHDH configuration..."
+
+kubectl apply -n rhdh -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config-rhdh
+  namespace: rhdh
+data:
+  app-config-kuadrant.yaml: |
+    app:
+      baseUrl: http://localhost:7007
+    backend:
+      baseUrl: http://localhost:7007
+      cors:
+        origin: http://localhost:7007
+
+    auth:
+      environment: development
+      providers:
+        guest:
+          dangerouslyAllowOutsideDevelopment: true
+          userEntityRef: user:default/guest
+
+    kubernetes:
+      serviceLocatorMethod:
+        type: multiTenant
+      clusterLocatorMethods:
+        - type: config
+          clusters:
+            - name: oinc
+              url: \${K8S_CLUSTER_URL}
+              authProvider: serviceAccount
+              serviceAccountToken: \${K8S_CLUSTER_TOKEN}
+              skipTLSVerify: true
+
+    catalog:
+      rules:
+        - allow: [Component, API, APIProduct, Location, Template, Domain, User, Group, System, Resource, Plugin, Package]
+
+    permission:
+      enabled: true
+      rbac:
+        admin:
+          superUsers:
+            - name: user:default/guest
+        policies-csv-file: /opt/app-root/src/rbac/rbac-policy.csv
+        policyFileReload: true
+
+    extensions:
+      installation:
+        enabled: true
+        saveToSingleFile:
+          file: /opt/app-root/src/dynamic-plugins-root/dynamic-plugins.yaml
+EOF
+
+# rbac policy from repo root, with guest as api-admin for local dev
+OINC_RBAC=$(mktemp)
+cat "${REPO_DIR}/rbac-policy.csv" > "${OINC_RBAC}"
+echo "g, user:default/guest, role:default/api-admin" >> "${OINC_RBAC}"
+kubectl create configmap rbac-policy-rhdh \
+  --namespace rhdh \
+  --from-file=rbac-policy.csv="${OINC_RBAC}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+rm -f "${OINC_RBAC}"
+
+# k8s credentials secret
+kubectl apply -n rhdh -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhdh-k8s-credentials
+  namespace: rhdh
+type: Opaque
+stringData:
+  K8S_CLUSTER_URL: "${CLUSTER_URL}"
+  K8S_CLUSTER_TOKEN: "${SA_TOKEN}"
+EOF
+
+# --- RHDH via Helm ---
+
+log "installing RHDH via Helm..."
+helm repo add rhdh https://redhat-developer.github.io/rhdh-chart/ --force-update
+
+RHDH_VALUES=$(mktemp)
+cat > "${RHDH_VALUES}" <<VALS
+global:
+  dynamic:
+    includes:
+      - dynamic-plugins.default.yaml
+    plugins:
+      # rbac management ui
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+        disabled: false
+      - package: "${BACKEND_PKG}"
+        disabled: false
+        integrity: "${BACKEND_HASH}"
+      - package: "${FRONTEND_PKG}"
+        disabled: false
+        integrity: "${FRONTEND_HASH}"
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              internal.plugin-kuadrant:
+                appIcons:
+                  - name: kuadrantIcon
+                    importName: KuadrantIcon
+                dynamicRoutes:
+                  - path: /kuadrant
+                    importName: KuadrantPage
+                  - path: /kuadrant/api-products
+                    importName: ApiProductsPage
+                    menuItem:
+                      icon: kuadrantIcon
+                      text: API Products
+                  - path: /kuadrant/my-api-keys
+                    importName: MyApiKeysPage
+                    menuItem:
+                      icon: kuadrantIcon
+                      text: My API Keys
+                  - path: /kuadrant/api-key-approval
+                    importName: ApiKeyApprovalPage
+                    menuItem:
+                      icon: kuadrantIcon
+                      text: API Key Approval
+                  - path: /kuadrant/api-products/:namespace/:name
+                    importName: ApiProductDetailPage
+                  - path: /kuadrant/api-keys/:namespace/:name
+                    importName: ApiKeyDetailPage
+                menuItems:
+                  kuadrant:
+                    icon: kuadrantIcon
+                    title: Kuadrant
+                  kuadrant.api-products:
+                    parent: kuadrant
+                  kuadrant.my-api-keys:
+                    parent: kuadrant
+                  kuadrant.api-key-approval:
+                    parent: kuadrant
+                mountPoints:
+                  - mountPoint: entity.page.api/cards
+                    importName: EntityKuadrantApiKeyManagementTab
+                    config:
+                      layout:
+                        gridColumn: "1 / -1"
+                      if:
+                        allOf:
+                          - isKind: api
+                  - mountPoint: entity.page.api/cards
+                    importName: EntityKuadrantApiProductInfoContent
+                    config:
+                      layout:
+                        gridColumn: "1 / -1"
+                      if:
+                        allOf:
+                          - isKind: api
+
+upstream:
+  backstage:
+    appConfig:
+      app:
+        baseUrl: http://localhost:7007
+      backend:
+        baseUrl: http://localhost:7007
+        cors:
+          origin: http://localhost:7007
+    initContainers:
+      - name: install-dynamic-plugins
+        image: '{{ include "backstage.image" . }}'
+        command:
+          - /bin/bash
+          - -c
+          - |
+            ./install-dynamic-plugins.sh /dynamic-plugins-root
+            # seed the extensions installation file so the UI can manage plugins
+            cp /opt/app-root/src/dynamic-plugins.yaml /dynamic-plugins-root/dynamic-plugins.yaml
+        env:
+          - name: NPM_CONFIG_USERCONFIG
+            value: /opt/app-root/src/.npmrc.dynamic-plugins
+          - name: MAX_ENTRY_SIZE
+            value: "30000000"
+        workingDir: /opt/app-root/src
+        volumeMounts:
+          - mountPath: /dynamic-plugins-root
+            name: dynamic-plugins-root
+          - mountPath: /opt/app-root/src/dynamic-plugins.yaml
+            name: dynamic-plugins
+            readOnly: true
+            subPath: dynamic-plugins.yaml
+          - mountPath: /opt/app-root/src/.npmrc.dynamic-plugins
+            name: dynamic-plugins-npmrc
+            readOnly: true
+            subPath: .npmrc
+          - mountPath: /opt/app-root/src/.config/containers
+            name: dynamic-plugins-registry-auth
+            readOnly: true
+          - mountPath: /opt/app-root/src/.npm/_cacache
+            name: npmcacache
+          - name: temp
+            mountPath: /tmp
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 2.5Gi
+            ephemeral-storage: 5Gi
+    extraAppConfig:
+      - configMapRef: app-config-rhdh
+        filename: app-config-kuadrant.yaml
+    extraEnvVarsSecrets:
+      - rhdh-k8s-credentials
+    extraVolumeMounts:
+      - name: dynamic-plugins-root
+        mountPath: /opt/app-root/src/dynamic-plugins-root
+      - name: extensions-catalog
+        mountPath: /extensions
+      - name: temp
+        mountPath: /tmp
+      - name: rbac-policy
+        mountPath: /opt/app-root/src/rbac
+    extraVolumes:
+      - name: dynamic-plugins-root
+        emptyDir: {}
+      - name: dynamic-plugins
+        configMap:
+          defaultMode: 420
+          name: rhdh-dynamic-plugins
+          optional: true
+      - name: dynamic-plugins-npmrc
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: rhdh-dynamic-plugins-npmrc
+      - name: dynamic-plugins-registry-auth
+        secret:
+          defaultMode: 416
+          optional: true
+          secretName: rhdh-dynamic-plugins-registry-auth
+      - name: npmcacache
+        emptyDir: {}
+      - name: extensions-catalog
+        emptyDir: {}
+      - name: temp
+        emptyDir: {}
+      - name: rbac-policy
+        configMap:
+          name: rbac-policy-rhdh
+  postgresql:
+    primary:
+      persistence:
+        enabled: false
+      resources:
+        limits:
+          ephemeral-storage: 2Gi
+VALS
+
+helm install rhdh rhdh/backstage \
+  --namespace rhdh \
+  --values "${RHDH_VALUES}" \
+  --timeout 900s \
+  --wait
+rm -f "${RHDH_VALUES}"
+
+# --- verify ---
+
+log "verifying RHDH deployment..."
+kubectl -n rhdh get pods
+log "RHDH is running"
+
+# --- done ---
+
+RHDH_SVC=$(kubectl -n rhdh get svc -l app.kubernetes.io/component=backstage -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "rhdh-developer-hub")
+RHDH_PORT=$(kubectl -n rhdh get svc "${RHDH_SVC}" -o jsonpath='{.spec.ports[0].port}' 2>/dev/null || echo "7007")
+
+echo ""
+echo "============================================"
+echo " RHDH installed"
+echo "============================================"
+echo ""
+echo " RHDH:"
+echo "   kubectl port-forward svc/${RHDH_SVC} 7007:${RHDH_PORT} -n rhdh"
+echo "   http://localhost:7007/kuadrant"
+echo ""
+echo " Verify plugins:"
+echo "   curl -H 'Authorization: Bearer <token>' http://localhost:7007/api/dynamic-plugins-info/loaded-plugins"
+echo ""

--- a/oinc/setup.sh
+++ b/oinc/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "${1:-}" in
+  --cluster) exec "${SCRIPT_DIR}/setup-cluster.sh" ;;
+  --rhdh)    exec "${SCRIPT_DIR}/setup-rhdh.sh" ;;
+  *)
+    "${SCRIPT_DIR}/setup-cluster.sh"
+    "${SCRIPT_DIR}/setup-rhdh.sh"
+    ;;
+esac

--- a/oinc/teardown.sh
+++ b/oinc/teardown.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+log "deleting oinc cluster..."
+oinc delete --force
+
+log "teardown complete"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
     "new": "backstage-cli new --scope internal",
     "repo:fix": "backstage-cli repo fix --publish",
     "versions:metadata": "node ./scripts/update-metadata.mjs",
-    "versions:bump": "node ./scripts/update-backstage.mjs"
+    "versions:bump": "node ./scripts/update-backstage.mjs",
+    "oinc": "./oinc/setup.sh",
+    "oinc:cluster": "./oinc/setup.sh --cluster",
+    "oinc:rhdh": "./oinc/setup.sh --rhdh",
+    "oinc:teardown": "./oinc/teardown.sh"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## oinc development environment

Local RHDH testing with dynamic plugins via [oinc](https://github.com/jasonmadigan/oinc) (OpenShift in a Container). Alternative to `yarn dev` for when you want stock RHDH rather than hot reload.

```bash
yarn oinc            # full setup: cluster + RHDH
yarn oinc:cluster    # cluster only (installation guide starting point)
yarn oinc:rhdh       # RHDH only (installation guide end state)
yarn oinc:teardown   # delete cluster
```

oinc handles the heavy lifting (Gateway API, cert-manager, MetalLB, Istio, Kuadrant, Console, OLM) via `oinc create --addons kuadrant`. Our scripts add the MetalLB IP pool, a Gateway resource, demo resources, and the RHDH Helm install.

See `docs/oinc.md` for details.

## Installation guide improvements

- Expanded the dynamic plugins config section with the full `dynamic-plugins.override.yaml` example (previously just said "copy from above", which was easy to get wrong)
- Added RBAC `superUsers` config with explanation