### PR TITLE
274 issues when deploying as dynamic plugin

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -733,6 +733,12 @@ plugins:
             appIcons:
               - name: kuadrantIcon
                 importName: KuadrantIcon
+              - name: apiIcon
+                importName: ApiIcon
+              - name: keyIcon
+                importName: KeyIcon
+              - name: approvalIcon
+                importName: ApprovalIcon
             menuItems:
               kuadrant.api-products:
                 parent: kuadrant
@@ -749,17 +755,17 @@ plugins:
               - path: /kuadrant/api-products
                 importName: ApiProductsPage
                 menuItem:
-                  icon: api
+                  icon: apiIcon
                   text: API Products
               - path: /kuadrant/my-api-keys
                 importName: MyApiKeysPage
                 menuItem:
-                  icon: key
+                  icon: keyIcon
                   text: My API Keys
               - path: /kuadrant/api-key-approval
                 importName: ApiKeyApprovalPage
                 menuItem:
-                  icon: approval
+                  icon: approvalIcon
                   text: API Key Approval
               - path: /kuadrant/api-products/:namespace/:name
                 importName: ApiProductDetailPage
@@ -901,6 +907,9 @@ rules:
 | `EntityKuadrantApiKeysContent`       | API keys content component                      |
 | `EntityKuadrantApiProductInfoContent`| APIProduct details tab                          |
 | `KuadrantIcon`                       | Kuadrant logo icon for navigation               |
+| `ApiIcon`                            | Api icon from standard MUI icons                |
+| `KeyIcon`                            | Key icon from standard MUI icons                |
+| `ApprovalIcon`                       | Approval icon from standard MUI icons           |
 
 ### Backend
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,10 +31,12 @@ The plugins require a Kubernetes cluster with Kuadrant installed. You can either
    - [Kuadrant operator 1.4+](https://docs.kuadrant.io/latest/getting-started/) installed
 
 2. **Use the development setup** (recommended for testing):
+
    ```bash
    cd kuadrant-dev-setup
    make kind-create
    ```
+
    This creates a kind cluster with:
    - Kuadrant operator
    - Gateway API CRDs v1.2.0
@@ -49,14 +51,16 @@ This section covers installing the Kuadrant plugins on a Red Hat Developer Hub d
 
 ### Prerequisites
 
-* Red Hat Developer Hub
+- Red Hat Developer Hub
 
-The Kuadrant plugins are tested and supported on **Red Hat Developer Hub 1.6** (based on Backstage 1.45.3).
+The Kuadrant plugins are tested and supported on **Red Hat Developer Hub 1.8.4** (based on Backstage 1.42.5).
 
 **Installation guide:**
+
 - [Installing Red Hat Developer Hub](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/)
 
 Choose your preferred deployment method:
+
 - Operator-based deployment (recommended for production)
 - Helm-based deployment
 
@@ -67,9 +71,12 @@ Set the following environment variables used for convenience in this tutorial:
 ```sh
 # Your backstage instance namespace. Choose your own.
 export RHDH_NS=rhdh
-export KUADRANT_PLUGIN_VERSION=v0.1.0
-export KUADRANT_BACKSTAGE_PLUGIN_BACKEND_DYNAMIC_SHA256=$(npm view @kuadrant/kuadrant-backstage-plugin-backend-dynamic@$KUADRANT_PLUGIN_VERSION dist.integrity)
-export KUADRANT_BACKSTAGE_PLUGIN_FRONTEND_SHA256=$(npm view @kuadrant/kuadrant-backstage-plugin-frontend@$KUADRANT_PLUGIN_VERSION dist.integrity)
+export KUADRANT_PLUGIN_VERSION=v0.2.1
+export KUADRANT_BACKSTAGE_PLUGIN_BACKEND_DYNAMIC="@kuadrant/kuadrant-backstage-plugin-backend-dynamic@$KUADRANT_PLUGIN_VERSION"
+export KUADRANT_BACKSTAGE_PLUGIN_BACKEND_DYNAMIC_SHA256=$(npm view ${KUADRANT_BACKSTAGE_PLUGIN_BACKEND_DYNAMIC} dist.integrity)
+export KUADRANT_BACKSTAGE_PLUGIN_FRONTEND="@kuadrant/kuadrant-backstage-plugin-frontend@$KUADRANT_PLUGIN_VERSION"
+export KUADRANT_BACKSTAGE_PLUGIN_FRONTEND_SHA256=$(npm view ${KUADRANT_BACKSTAGE_PLUGIN_FRONTEND} dist.integrity)
+
 # base hostname of the cluster.
 # In openshift, this can be easily read with the following command
 #  oc get ingress.config.openshift.io cluster -o jsonpath='{.spec.domain}'
@@ -81,7 +88,13 @@ export CLUSTER_HOSTNAME=apps.example.com
 Create namespace for the backstage instance
 
 ```sh
-kubectl create namespace $RHDH_NS
+kubectl apply -f - <<EOF
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $RHDH_NS
+EOF
 ```
 
 #### Dynamic Plugin ConfigMap
@@ -89,7 +102,6 @@ kubectl create namespace $RHDH_NS
 Create a config map with the dynamic plugin configuration required to load kuadrant backstage plugins as dynamic plugins.
 
 Copy [Kuadrant backstage dynamic plugins metadata](#dynamic-plugins) into a file named, for example, `dynamic-plugins-rhdh.yaml`. Replace the environment variables with their actual values. Then, create `dynamic-plugins-rhdh` configmap from that file.
-
 
 ```sh
 kubectl create configmap dynamic-plugins-rhdh --from-file=dynamic-plugins-rhdh.yaml --namespace=$RHDH_NS
@@ -149,11 +161,13 @@ The recommended approach is so-called `in-cluster` mode. In this mode, the backs
 The `in-cluster` mode can be configured by either:
 
 - Omitting the `kubernetes` section entirely (setting it to null):
+
   ```yaml
   kubernetes: null
   ```
 
 - Omitting the `serviceAccountToken` when configuring clusters:
+
   ```yaml
   kubernetes:
     serviceLocatorMethod:
@@ -214,6 +228,9 @@ kubernetes: null
 catalog:
   rules:
     - allow: [Component, API, APIProduct, Location, Template, Domain, User, Group, System, Resource, Plugin, Package]
+  locations:
+    - type: file
+      target: /opt/app-root/src/catalog-entities/all.yaml
 
 permission:
   enabled: true
@@ -234,7 +251,7 @@ kubectl create configmap rhdh-app-config --from-file=app-config.yaml --namespace
 
 This step grants permissions to the backstage application to manage kuadrant CRD's existing in the cluster. It consist on two steps: creating the clusterRole and then the ClusterRoleBinding.
 
-First, create the [ClusterRole](#clusterrole) which defines permissions on the kuadrant CRD's.
+First, create the [ClusterRole](#kuadrant-clusterrole) which defines permissions on the kuadrant CRD's.
 
 By default, backstage application will run with the `default` service account of the namespace.
 Thus, secondly, we need to bind that cluster role to this service account with cluster wide scope. Therefore, create *CluterRoleBinding* as follows:
@@ -266,7 +283,7 @@ kubectl auth can-i update apikeys.devportal.kuadrant.io --as=system:serviceaccou
 
 The Backstage CR represents one backstage instance. It is where all preparation comes into one place and takes effect.
 
-* Link the dynamic plugin configmap
+- Link the dynamic plugin configmap
 
 ```yaml
 spec:
@@ -274,7 +291,7 @@ spec:
     dynamicPluginsConfigMapName: dynamic-plugins-rhdh
 ```
 
-* Link the main `rhdh-app-config` configmap
+- Link the main `rhdh-app-config` configmap
 
 ```yaml
 spec:
@@ -285,7 +302,7 @@ spec:
          - name: rhdh-app-config
 ```
 
-* Link the RBAC policies from the `rbac-policies` configmap
+- Link the RBAC policies from the `rbac-policies` configmap
 
 ```yaml
 spec:
@@ -295,9 +312,10 @@ spec:
       configMaps:
          - name: rbac-policies
 ```
+
 > The mounting path is referenced from `app-config.yaml`, RBAC for the kuadrant functionality section. Ensure they match.
 
-* [Optional] Enable serviceaccount token automount
+- [Optional] Enable serviceaccount token automount
 
 Only required for kubernetes access *in-cluster* mode.
 
@@ -357,6 +375,7 @@ This section covers installing the plugins using [rhdh-local](https://github.com
 Copy [Kuadrant backstage dynamic plugins metadata](#dynamic-plugins) into a file named `configs/dynamic-plugins/dynamic-plugins.override.yaml`:
 
 To get the integrity hash:
+
 ```bash
 npm view @kuadrant/kuadrant-backstage-plugin-frontend dist.integrity
 npm view @kuadrant/kuadrant-backstage-plugin-backend-dynamic dist.integrity
@@ -452,7 +471,7 @@ EOF
 docker compose up
 ```
 
-Visit http://localhost:7007/kuadrant
+Visit <http://localhost:7007/kuadrant>
 
 ## Installation on Backstage
 
@@ -683,7 +702,7 @@ EOF
 yarn start
 ```
 
-Visit http://localhost:3000/kuadrant
+Visit <http://localhost:3000/kuadrant>
 
 ---
 
@@ -709,15 +728,39 @@ plugins:
       dynamicPlugins:
         frontend:
           internal.plugin-kuadrant:
+            apiFactories:
+              - importName: kuadrantApiFactory
             appIcons:
               - name: kuadrantIcon
                 importName: KuadrantIcon
+            menuItems:
+              kuadrant.api-products:
+                parent: kuadrant
+              kuadrant.my-api-keys:
+                parent: kuadrant
+              kuadrant.api-key-approval:
+                parent: kuadrant
             dynamicRoutes:
               - path: /kuadrant
                 importName: KuadrantPage
                 menuItem:
                   icon: kuadrantIcon
                   text: Kuadrant
+              - path: /kuadrant/api-products
+                importName: ApiProductsPage
+                menuItem:
+                  icon: api
+                  text: API Products
+              - path: /kuadrant/my-api-keys
+                importName: MyApiKeysPage
+                menuItem:
+                  icon: key
+                  text: My API Keys
+              - path: /kuadrant/api-key-approval
+                importName: ApiKeyApprovalPage
+                menuItem:
+                  icon: approval
+                  text: API Key Approval
               - path: /kuadrant/api-products/:namespace/:name
                 importName: ApiProductDetailPage
               - path: /kuadrant/api-keys/:namespace/:name
@@ -795,7 +838,7 @@ g, group:default/api-admins, role:default/api-admin
 g, user:default/guest, role:default/api-admin
 ```
 
-### ClusterRole
+### Kuadrant ClusterRole
 
 Permissions to manage resources from kuadrant CRDs.
 

--- a/packages/app/src/components/DynamicRoot/CommonIcons.tsx
+++ b/packages/app/src/components/DynamicRoot/CommonIcons.tsx
@@ -1,3 +1,4 @@
+import { KuadrantIcon } from '@kuadrant/kuadrant-backstage-plugin-frontend';
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
 import AddCircle from '@mui/icons-material/AddCircleOutline';
 import Api from '@mui/icons-material/ApiOutlined';
@@ -31,7 +32,6 @@ import Support from '@mui/icons-material/Support';
 import Textsms from '@mui/icons-material/TextsmsOutlined';
 import WavingHand from '@mui/icons-material/WavingHandOutlined';
 
-import { KuadrantIcon } from '@kuadrant/kuadrant-backstage-plugin-frontend';
 import DeveloperHub from '../CustomIcons/DeveloperHub';
 
 const CommonIcons: {

--- a/packages/app/src/components/DynamicRoot/CommonIcons.tsx
+++ b/packages/app/src/components/DynamicRoot/CommonIcons.tsx
@@ -31,8 +31,8 @@ import Support from '@mui/icons-material/Support';
 import Textsms from '@mui/icons-material/TextsmsOutlined';
 import WavingHand from '@mui/icons-material/WavingHandOutlined';
 
+import { KuadrantIcon } from '@kuadrant/kuadrant-backstage-plugin-frontend';
 import DeveloperHub from '../CustomIcons/DeveloperHub';
-import Kuadrant from '../CustomIcons/Kuadrant';
 
 const CommonIcons: {
   [k: string]: React.ComponentType<{}>;
@@ -70,7 +70,7 @@ const CommonIcons: {
   key: Key,
   api: Api,
   approval: Approval,
-  kuadrant: Kuadrant,
+  kuadrant: KuadrantIcon,
 };
 
 export default CommonIcons;

--- a/plugins/kuadrant/package.json
+++ b/plugins/kuadrant/package.json
@@ -57,6 +57,7 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.61",
+    "@mui/material": "5.18.0",
     "async-retry": "^1.3.3",
     "react-router-dom": "^6.0.0",
     "react-use": "^17.2.4"

--- a/plugins/kuadrant/package.json
+++ b/plugins/kuadrant/package.json
@@ -24,7 +24,7 @@
   "scalprum": {
     "name": "internal.plugin-kuadrant",
     "exposedModules": {
-      "PluginRoot": "./src/plugin.ts",
+      "PluginRoot": "./src/index.ts",
       "KuadrantPage": "./src/plugin.ts",
       "EntityKuadrantApiAccessCard": "./src/plugin.ts",
       "EntityKuadrantApiKeyManagementTab": "./src/plugin.ts",

--- a/plugins/kuadrant/package.json
+++ b/plugins/kuadrant/package.json
@@ -47,6 +47,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
+    "@backstage/catalog-model": "1.7.5",
     "@backstage/core-components": "^0.17.5",
     "@backstage/core-plugin-api": "^1.10.9",
     "@backstage/plugin-api-docs": "^0.12.10",

--- a/plugins/kuadrant/package.json
+++ b/plugins/kuadrant/package.json
@@ -29,7 +29,8 @@
       "EntityKuadrantApiAccessCard": "./src/plugin.ts",
       "EntityKuadrantApiKeyManagementTab": "./src/plugin.ts",
       "EntityKuadrantApiKeysContent": "./src/plugin.ts",
-      "EntityKuadrantApiProductInfoContent": "./src/plugin.ts"
+      "EntityKuadrantApiProductInfoContent": "./src/plugin.ts",
+      "KuadrantIcon": "./src/components/KuadrantIcon"
     }
   },
   "sideEffects": false,

--- a/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
@@ -31,7 +31,8 @@ import {
   alertApiRef,
 } from "@backstage/core-plugin-api";
 import { kuadrantApiRef } from '../../api';
-import { useEntity } from "@backstage/plugin-catalog-react";
+import { UserEntity } from '@backstage/catalog-model';
+import { useEntity, catalogApiRef } from "@backstage/plugin-catalog-react";
 import VisibilityIcon from "@material-ui/icons/Visibility";
 import VisibilityOffIcon from "@material-ui/icons/VisibilityOff";
 import HourglassEmptyIcon from "@material-ui/icons/HourglassEmpty";
@@ -64,6 +65,7 @@ export const ApiKeyManagementTab = ({
   namespace: propNamespace,
 }: ApiKeyManagementTabProps) => {
   const { entity } = useEntity();
+  const catalogAPI = useApi(catalogApiRef);
   const kuadrantApi = useApi(kuadrantApiRef);
   const identityApi = useApi(identityApiRef);
   const alertApi = useApi(alertApiRef);
@@ -113,7 +115,18 @@ export const ApiKeyManagementTab = ({
     const identity = await identityApi.getBackstageIdentity();
     const profile = await identityApi.getProfileInfo();
     setUserId(identity.userEntityRef);
-    setUserEmail(profile.email || "");
+
+    // Try profile email first (works for OAuth providers)
+    let email = profile.email || "";
+    // Fallback to catalog entity for guest/other providers
+    if (!email && identity.userEntityRef) {
+       const userEntity = await catalogAPI.getEntityByRef(identity.userEntityRef) as UserEntity;
+        if (userEntity?.spec?.profile?.email) {
+          email = userEntity.spec.profile.email as string;
+        }
+    }
+
+    setUserEmail(email);
   }, [identityApi]);
 
   const {
@@ -813,12 +826,22 @@ export const ApiKeyManagementTab = ({
                 color="primary"
                 startIcon={<AddIcon />}
                 onClick={() => setRequestDialogOpen(true)}
-                disabled={plans.length === 0}
+                disabled={plans.length === 0 || !userEmail}
                 data-testid="request-api-access-button"
                 data-plans-count={plans.length}
               >
                 Request API Access
               </Button>
+              {!userEmail && (
+                <Typography
+                  variant="caption"
+                  color="textSecondary"
+                  style={{ marginTop: 4 }}
+                  data-testid="no-email-message"
+                 >
+                "Email address is required"
+                </Typography>
+              )}
               {plans.length === 0 && (
                 <Typography
                   variant="caption"

--- a/plugins/kuadrant/src/components/KuadrantIcon/KuadrantIcon.tsx
+++ b/plugins/kuadrant/src/components/KuadrantIcon/KuadrantIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 
-const KuadrantIcon = (props: SvgIconProps) => (
+export const KuadrantIcon = (props: SvgIconProps) => (
   <SvgIcon
     {...props}
     viewBox="0 0 1024 1024"
@@ -14,5 +14,3 @@ const KuadrantIcon = (props: SvgIconProps) => (
     <rect x="1" y="1" width="218" height="1022" fill="currentColor" />
   </SvgIcon>
 );
-
-export default KuadrantIcon;

--- a/plugins/kuadrant/src/components/KuadrantIcon/KuadrantIcon.tsx
+++ b/plugins/kuadrant/src/components/KuadrantIcon/KuadrantIcon.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 
 const KuadrantIcon = (props: SvgIconProps) => (

--- a/plugins/kuadrant/src/components/KuadrantIcon/index.ts
+++ b/plugins/kuadrant/src/components/KuadrantIcon/index.ts
@@ -1,1 +1,1 @@
-export { default as KuadrantIcon } from './KuadrantIcon';
+export { KuadrantIcon } from './KuadrantIcon';

--- a/plugins/kuadrant/src/components/KuadrantIcon/index.ts
+++ b/plugins/kuadrant/src/components/KuadrantIcon/index.ts
@@ -1,0 +1,1 @@
+export { default as KuadrantIcon } from './KuadrantIcon';

--- a/plugins/kuadrant/src/components/icons.tsx
+++ b/plugins/kuadrant/src/components/icons.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ApiOutlined from '@mui/icons-material/ApiOutlined';
+import KeyOutlined from '@mui/icons-material/KeyOutlined';
+import ApprovalOutlined from '@mui/icons-material/ApprovalOutlined';
+import { SvgIconProps } from '@mui/material/SvgIcon';
+
+export const ApiIcon = (props: SvgIconProps) => <ApiOutlined {...props} />;
+export const KeyIcon = (props: SvgIconProps) => <KeyOutlined {...props} />;
+export const ApprovalIcon = (props: SvgIconProps) => <ApprovalOutlined {...props} />;

--- a/plugins/kuadrant/src/index.ts
+++ b/plugins/kuadrant/src/index.ts
@@ -16,6 +16,7 @@ export {
 export { ApiAccessCard } from './components/ApiAccessCard';
 export { ApiKeyManagementTab } from './components/ApiKeyManagementTab';
 export { ApiProductInfoCard } from './components/ApiProductInfoCard';
+export { KuadrantIcon } from './components/KuadrantIcon';
 
 export {
   kuadrantPlanPolicyCreatePermission,

--- a/plugins/kuadrant/src/index.ts
+++ b/plugins/kuadrant/src/index.ts
@@ -17,6 +17,7 @@ export { ApiAccessCard } from './components/ApiAccessCard';
 export { ApiKeyManagementTab } from './components/ApiKeyManagementTab';
 export { ApiProductInfoCard } from './components/ApiProductInfoCard';
 export { KuadrantIcon } from './components/KuadrantIcon';
+export { ApiIcon, KeyIcon, ApprovalIcon } from './components/icons';
 
 export {
   kuadrantPlanPolicyCreatePermission,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11036,6 +11036,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kuadrant/kuadrant-backstage-plugin-frontend@workspace:plugins/kuadrant"
   dependencies:
+    "@backstage/catalog-model": 1.7.5
     "@backstage/cli": ^0.34.1
     "@backstage/core-app-api": ^1.18.0
     "@backstage/core-components": ^0.17.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -11051,6 +11051,7 @@ __metadata:
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.61
+    "@mui/material": 5.18.0
     "@testing-library/jest-dom": ^6.0.0
     "@testing-library/react": ^16.3.0
     "@testing-library/user-event": ^14.0.0


### PR DESCRIPTION
Fixes #274 

- [x] Page shows `No implementation available for apiRef{plugin.kuadrant.service}`. Very likely that kuadrant api factory is not exported. 
- [x] Only one menu item in the sidebar `Kuadrant`. Missing sub menu items `API Products`, `My API Keys` and `API Key Approval`. 
- [x] Kuadrant icon not shown
- [x] `guest` auth provider does not provide email in the profile. Fallback to catalog entity to fetch the email. Now the api key creation works in both auth providers: guest and oidc based. 
- [x] Updated doc to latest supported RHDH and backstage versions (from https://github.com/Kuadrant/kuadrant-backstage-plugin/pull/261)
- [x] Export standard MUI icons (api, key, approval) 

With these changes:

<img width="220" height="279" alt="Screenshot 2026-03-25 at 16-46-33 API Products Eguzki&#39;s Red Hat Developer Hub" src="https://github.com/user-attachments/assets/86d11385-5f51-4a00-9124-54fe8b70a5cd" />