### PR TITLE
fix: remove required indicator from OpenAPI Spec URL field

### DIFF
--- a/plugins/kuadrant/src/components/CreateAPIProductDialog/CreateAPIProductDialog.tsx
+++ b/plugins/kuadrant/src/components/CreateAPIProductDialog/CreateAPIProductDialog.tsx
@@ -501,13 +501,7 @@ export const CreateAPIProductDialog = ({ open, onClose, onSuccess }: CreateAPIPr
               helperText={openAPISpecError || "Enter the full path to your API spec file"}
               error={!!openAPISpecError}
               margin="normal"
-              required
               disabled={creating}
-              InputLabelProps={{
-                classes: {
-                  asterisk: classes.asterisk,
-                },
-              }}
             />
           </Grid>
           <Grid item xs={12}>


### PR DESCRIPTION
## Summary
- Removed the required indicator (asterisk) from the OpenAPI Spec URL field in the Create API Product dialog
- This fixes the inconsistency where the field showed as required but validation allowed empty submission
- The field is now consistently optional in both Create and Edit dialogs

## Changes
- Removed `required` prop from OpenAPI Spec URL TextField in CreateAPIProductDialog
- Removed associated `InputLabelProps` that styled the asterisk

## Why this approach?
The field is actually optional:
- The backend only includes `openAPISpecURL` in the API product when a value is provided
- The `validateURL()` function returns `null` (no error) for empty values
- The Edit dialog already treats this field as optional (no asterisk shown)

Fixes #254

## Test plan
- [x] Review code changes
- [ ] Manually test Create API Product dialog - verify no asterisk shown for OpenAPI Spec URL
- [ ] Verify form can be submitted without OpenAPI Spec URL value
- [ ] Verify Edit API Product dialog still works correctly (no asterisk shown)
- [ ] Verify URL validation still works when a value is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)