### PR TITLE
feat: migrate MyApiKeysPage to status.conditions schema (#282)

### DIFF
--- a/plugins/kuadrant/src/components/MyApiKeysTable/MyApiKeysTable.tsx
+++ b/plugins/kuadrant/src/components/MyApiKeysTable/MyApiKeysTable.tsx
@@ -485,7 +485,7 @@ export const MyApiKeysTable = () => {
                 ? "Loading..."
                 : isVisible && apiKeyValue
                   ? apiKeyValue
-                  : "•".repeat(20) + "..."}
+                  : "•".repeat(20)}
             </Box>
             {isVisible && apiKeyValue && (
               <Tooltip title="Copy to clipboard">


### PR DESCRIPTION
## Summary

Migrates MyApiKeysPage (issue #282) from `status.phase` to `status.conditions` schema as part of Epic #281 (namespace-based RBAC design).

<img width="2344" height="769" alt="Screenshot 2026-05-18 at 21 22 40" src="https://github.com/user-attachments/assets/1ab56c78-6644-4469-8200-81789d60e867" />
<img width="2566" height="848" alt="Screenshot 2026-05-18 at 21 27 12" src="https://github.com/user-attachments/assets/deab6956-ab83-4d6c-b168-8b690c8b5b69" />

<img width="2545" height="767" alt="Screenshot 2026-05-18 at 21 29 23" src="https://github.com/user-attachments/assets/29c967ba-38d9-4a65-86be-b8351a71b77b" />


### Changes

**Core Utility:**
- Created `getAPIKeyPhase()` utility to derive approval phase from Kubernetes conditions
- Supports Approved, Denied, Failed, and Pending states
- Priority: Approved > Denied > Failed > Pending

**Type Updates:**
- Added `spec.secretRef` and `spec.apiProductRef.namespace` fields
- Marked deprecated fields in `APIKeyStatus` with `@deprecated` JSDoc
- Supports incremental migration (issues #283-287 will migrate other components)

**Frontend (MyApiKeysTable):**
- Replaced all `status.phase` checks with `getAPIKeyPhase(status.conditions)`
- Updated secret viewing to use `spec.secretRef` instead of `status.secretRef`
- Removed `canReadSecret` one-time viewing restriction
- Maps "Denied" → "Rejected" for display

**Backend:**
- Updated secret endpoint to use `spec.secretRef.name`
- Removed `canReadSecret` permission check and status patch
- Fixed critical bug: removed non-existent `.key` field check

### Test Plan

- [x] Unit tests: 6/6 apikeys utility tests passing
- [x] TypeScript compilation: No errors in kuadrant plugins
- [x] Code review: Critical bug fixed (secret viewing broken)
- [ ] Manual testing: See instructions below

### Manual Testing Instructions

**Prerequisites:**
1. Kind cluster running with Kuadrant setup:
   ```bash
   cd kuadrant-dev-setup
   make kind-create
   cd ..
   ```
2. App running with this PR's changes:
   ```bash
   yarn dev
   ```
3. Navigate to: http://localhost:3000/kuadrant/my-api-keys

**Test Scenarios:**

#### 1. Status Display (status.conditions → getAPIKeyPhase)
- [ ] **Pending status**: Create a new API key request
  - Badge shows "Pending" in purple
  - Edit button enabled
  - "Show secret" column shows "-"
  
- [ ] **Approved status**: Approve a pending request
  - Badge shows "Active" (not "Approved") in blue
  - Edit button disabled
  - "Show secret" column shows reveal button
  
- [ ] **Rejected status**: Reject a pending request
  - Badge shows "Rejected" in red
  - Rejected banner appears in expanded row
  - Edit button disabled

#### 2. Status Filtering
- [ ] Filter by status dropdown shows counts for each status
- [ ] Selecting "Pending" filters to show only pending requests
- [ ] Selecting "Approved" filters to show only approved requests
- [ ] Selecting "Rejected" filters to show only rejected requests
- [ ] Multiple filters work together (e.g., Pending + Approved)

#### 3. Secret Viewing (Multiple Reveals - canReadSecret removed)
- [ ] Click "Reveal API key" button on approved request
  - Dialog shows new text: "You are about to reveal the API key"
  - Does NOT say "viewed once" or "one-time only"
- [ ] Click "Reveal" in dialog
  - API key displays in monospace font
  - Eye icon shows (visibility on)
  - Copy button works
- [ ] Click eye icon again to hide
  - API key hidden
  - Eye-off icon shows
- [ ] Click eye icon again to reveal
  - **API key displays again** (multiple reveals work)
  - No 403 error
  - No "already viewed" message

#### 4. Error Handling
- [ ] Approved key without secretRef shows appropriate error
- [ ] Network errors show transient error alert (not "already viewed" warning)

#### 5. Backward Compatibility (During Migration)
- [ ] Existing APIKeys with old `status.phase` still work (if present)
- [ ] New APIKeys with `status.conditions` work correctly

### Related

- Epic: #281
- Implements: #282 (MyApiKeysPage/MyApiKeysTable)
- Implements: #295 (GET /apikeys/:namespace/:name/secret)
- Next: #283 (ApiKeyDetailPage), #284 (ApprovalQueueTable), #285 (ApiKeyManagementTab), #286 (EntityApiApprovalTab), #287 (ApiAccessCard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Failed" status for improved API key state visibility
  * Enhanced error alerts for secret retrieval operations

* **Bug Fixes**
  * Removed one-time-only viewing limitation on API keys
  * Improved API key lifecycle state display and UI handling across different approval phases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-backstage-plugin/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->