### PR TITLE
Fix ApiKeyDetailPage for status.conditions migration

### DIFF
--- a/plugins/kuadrant/src/components/ApiKeyDetailPage/ApiKeyDetailPage.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyDetailPage/ApiKeyDetailPage.tsx
@@ -341,25 +341,21 @@ func main() {
                     : "-"}
                 </Typography>
 
-                {apiKey.status?.reviewedBy && (
-                  <>
-                    <Typography variant="caption" className={classes.label}>
-                      Reviewed By
-                    </Typography>
-                    <Typography variant="body1" className={classes.value}>
-                      {apiKey.status.reviewedBy.replace(/^user:default\//, "")}
-                      {apiKey.status.reviewedAt && (
-                        <Typography variant="caption" color="textSecondary">
-                          {" "}
-                          on{" "}
-                          {new Date(
-                            apiKey.status.reviewedAt,
-                          ).toLocaleDateString()}
-                        </Typography>
-                      )}
-                    </Typography>
-                  </>
-                )}
+                {(() => {
+                  const approvalDate = apiKey.status?.conditions?.find(
+                    c => c.type === 'Approved' && c.status === 'True'
+                  )?.lastTransitionTime;
+                  return approvalDate ? (
+                    <>
+                      <Typography variant="caption" className={classes.label}>
+                        Approved On
+                      </Typography>
+                      <Typography variant="body1" className={classes.value}>
+                        {new Date(approvalDate).toLocaleDateString()}
+                      </Typography>
+                    </>
+                  ) : null;
+                })()}
               </Box>
             </InfoCard>
           </Grid>


### PR DESCRIPTION
## Summary
Completes the `status.conditions` migration for `ApiKeyDetailPage`.

Most of the required changes from #283 were already addressed in prior PRs:
- `status.phase` → `getAPIKeyPhase(conditions)` (done in #284)
- `canReadSecret` / "already viewed" one-time restriction logic removed
- Secret fetching simplified (no longer uses `status.secretRef`)

This PR handles the remaining item:
- Replaced deprecated `reviewedBy`/`reviewedAt` fields with "Approved On" date derived from `status.conditions`

## Test Plan
- [ ] View approved API key — verify "Approved On" date displays correctly
- [ ] View pending API key — verify no "Approved On" field appears
- [ ] TypeScript compilation passes

## Related
Closes #283
Part of #281 (status.conditions migration epic)