### PR TITLE
fix: fetch API keys from consumer namespaces

### DIFF
--- a/plugins/kuadrant/src/components/ApiAccessCard/ApiAccessCard.tsx
+++ b/plugins/kuadrant/src/components/ApiAccessCard/ApiAccessCard.tsx
@@ -57,10 +57,14 @@ export const ApiAccessCard = ({ namespace: propNamespace }: ApiAccessCardProps) 
 
   // fetch user's approved keys
   const { value: requests, loading: keysLoading, error: keysError } = useAsync(async () => {
-    const data = await kuadrantApi.getRequestsByNamespace(namespace)
+    // Fetch all user's API keys (they live in consumer namespaces, not APIProduct namespace)
+    const data = await kuadrantApi.getRequests();
     const allRequests = data.items || [];
+    // Filter by APIProduct reference and approved status
     return allRequests.filter((r: APIKey) =>
-      r.spec.apiProductRef?.name === apiProductName && getAPIKeyPhase(r.status?.conditions || []) === 'Approved'
+      r.spec.apiProductRef?.name === apiProductName &&
+      r.spec.apiProductRef?.namespace === namespace &&
+      getAPIKeyPhase(r.status?.conditions || []) === 'Approved'
     );
   }, [namespace, apiProductName, kuadrantApi, refresh]);
 

--- a/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
@@ -134,8 +134,9 @@ export const ApiKeyManagementTab = ({
     loading: requestsLoading,
     error: requestsError,
   } = useAsync(async () => {
-    const data = await kuadrantApi.getRequestsByNamespace(namespace);
-    // filter by apiproduct name and namespace (APIKey lives in consumer's NS, refs APIProduct in owner's NS)
+    // Fetch all user's API keys (they live in consumer namespaces, not APIProduct namespace)
+    const data = await kuadrantApi.getRequests();
+    // Filter by APIProduct reference (APIKey lives in consumer's NS, refs APIProduct in owner's NS)
     return (data.items || []).filter(
       (r: APIKey) =>
         r.spec.apiProductRef.name === apiProductName &&

--- a/plugins/kuadrant/src/components/KuadrantPage/ApiProductsPage.tsx
+++ b/plugins/kuadrant/src/components/KuadrantPage/ApiProductsPage.tsx
@@ -456,10 +456,11 @@ const ResourceList = () => {
     setDeleteStats(null);
 
     try {
-      const data = await kuadrantApi.getRequestsByNamespace(namespace);
+      // Fetch all API keys across all namespaces to find those referencing this APIProduct
+      const data = await kuadrantApi.getAllRequests();
       const related = (data.items || []).filter(
         (r: any) =>
-          r.spec.apiName === name && r.spec.apiNamespace === namespace,
+          r.spec.apiProductRef?.name === name && r.spec.apiProductRef?.namespace === namespace,
       );
       const approved = related.filter(
         (r: any) => r.status?.phase === "Approved",
@@ -469,7 +470,7 @@ const ResourceList = () => {
       const errorMessage =
         err instanceof Error ? err.message : "unknown error occurred";
       alertApi.post({
-        message: `Failed to delete access request: ${errorMessage}`,
+        message: `Failed to count related API keys: ${errorMessage}`,
         severity: "error",
         display: "transient",
       });


### PR DESCRIPTION
## Summary
Fix API key retrieval to work with the new RBAC model where API keys live in consumer-specific namespaces instead of APIProduct namespaces.

## Problem
With the new RBAC model, API keys are created in consumer-specific namespaces like `kuadrant-consumer1-3ef37f33`, not in the APIProduct's namespace (e.g., `toystore`). Three components were incorrectly calling `getRequestsByNamespace(namespace)` where `namespace` was the APIProduct's namespace, resulting in **zero API keys found**.

## Changes

### 1. ApiAccessCard (Entity Overview card)
- **Before:** `getRequestsByNamespace(namespace)` → fetched from APIProduct namespace → empty results
- **After:** `getRequests()` → fetches all user's keys across all consumer namespaces
- **Filter:** By `apiProductRef.name`, `apiProductRef.namespace`, and `Approved` phase

### 2. ApiKeyManagementTab (API Product "API Keys" tab)
- **Before:** `getRequestsByNamespace(namespace)` → fetched from APIProduct namespace → empty results
- **After:** `getRequests()` → fetches all user's keys across all consumer namespaces
- **Filter:** By `apiProductRef.name` and `apiProductRef.namespace`

### 3. ApiProductsPage (Delete APIProduct dialog)
- **Before:** `getRequestsByNamespace(namespace)` → fetched from APIProduct namespace → empty results
- **After:** `getAllRequests()` → fetches all API keys across all users/namespaces (needed for admin view)
- **Filter:** By `apiProductRef.name` and `apiProductRef.namespace` (also fixed incorrect field names `spec.apiName` → `spec.apiProductRef.name`)

## Technical Details

**New RBAC Model:**
- API keys live in: `kuadrant-consumer1-{hash}` (consumer namespace)
- API keys reference: `spec.apiProductRef.namespace` + `spec.apiProductRef.name` (APIProduct location)
- Old approach assumed API keys lived in same namespace as APIProduct

**Backend API:**
- `getRequests()` - fetches current user's API keys (filtered by `spec.requestedBy.userId` on backend)
- `getAllRequests()` - fetches all API keys across all users (admin view)
- `getRequestsByNamespace(ns)` - fetches from specific namespace (now only useful for legacy/specific cases)

## Test plan
- [x] TypeScript compilation passes
- [ ] Navigate to an API Product entity page → "API Keys" tab shows keys
- [ ] Navigate to an API Product entity page → Overview card shows active keys
- [ ] Delete APIProduct shows correct count of related keys in confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)