### PR TITLE
fix: migrate PATCH edit endpoint to status.conditions schema (#293)

### DIFF
--- a/plugins/kuadrant-backend/src/router.ts
+++ b/plugins/kuadrant-backend/src/router.ts
@@ -1520,7 +1520,22 @@ export async function createRouter({
       );
 
       const requestUserId = existing.spec?.requestedBy?.userId;
-      const currentPhase = existing.status?.phase || 'Pending';
+
+      let currentPhase = 'Pending';
+      const conditions = existing.status?.conditions;
+      if (conditions && conditions.length > 0) {
+        const approved = conditions.find(
+          (c: any) => c.type === 'Approved' && c.status === 'True'
+        );
+        if (approved) {
+          currentPhase = 'Approved';
+        } else {
+          const denied = conditions.find(
+            (c: any) => c.type === 'Denied' && c.status === 'True'
+          );
+          if (denied) currentPhase = 'Denied';
+        }
+      }
 
       // only pending requests can be edited
       if (currentPhase !== 'Pending') {


### PR DESCRIPTION
## Summary
Closes #293, part of #281

The PATCH `/requests/:namespace/:name` endpoint was the last backend endpoint still reading `status.phase` directly. This replaces it with inline conditions parsing (same pattern used at line 970 for the GET `/requests` filter).

Frontend edit dialog already guards on `getAPIKeyPhase(conditions)` so no frontend changes needed.

## Test Plan
- [ ] TypeScript compilation passes
- [ ] Backend tests pass (8/8)
- [ ] Edit a pending API key request — should succeed
- [ ] Attempt to edit an approved API key request — should return 403