### PR TITLE
fix: restrict delete endpoint to consumer self-delete (#294)

### DIFF
--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -12,15 +12,6 @@ if (args.some((arg) => arg.includes("showcase-localization-fr"))) {
   process.env.LOCALE = "en";
 }
 
-const k8sSpecificConfig = {
-  use: {
-    actionTimeout: 15 * 1000,
-  },
-  expect: {
-    timeout: 15 * 1000, // Global expect timeout
-  },
-};
-
 export default defineConfig({
   timeout: 90 * 1000,
   testDir: "./playwright",

--- a/e2e-tests/playwright/e2e/kuadrant-auth-schemes.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-auth-schemes.spec.ts
@@ -31,15 +31,17 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("should show OIDC tab", async ({ page }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       const oidcTab = page.getByRole("tab", { name: "OIDC" });
       await expect(oidcTab).toBeVisible({ timeout: TIMEOUTS.SLOW });
     });
 
-    test("should show OIDC Provider Discovery card in OIDC tab", async ({ page }) => {
+    test("should show OIDC Provider Discovery card in OIDC tab", async ({
+      page,
+    }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // click on OIDC tab
       const oidcTab = page.getByRole("tab", { name: "OIDC" });
@@ -51,7 +53,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("should show identity provider URL in OIDC tab", async ({ page }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // click on OIDC tab
       const oidcTab = page.getByRole("tab", { name: "OIDC" });
@@ -63,7 +65,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("should show token endpoint URL in OIDC tab", async ({ page }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // click on OIDC tab
       const oidcTab = page.getByRole("tab", { name: "OIDC" });
@@ -75,7 +77,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("should show curl example in OIDC tab", async ({ page }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // click on OIDC tab
       const oidcTab = page.getByRole("tab", { name: "OIDC" });
@@ -87,7 +89,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("should NOT show API Key Approval field", async ({ page }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // wait for page to load
       const productCard = page.getByText("API Product").first();
@@ -104,7 +106,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("should show API Key Approval field", async ({ page }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       const apiKeyApproval = page.getByText("API Key Approval");
       await expect(apiKeyApproval).toBeVisible({ timeout: TIMEOUTS.SLOW });
@@ -112,7 +114,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("should NOT show OIDC tab", async ({ page }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // wait for page to load
       const productCard = page.getByText("API Product").first();
@@ -130,7 +132,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("should show OIDC tab and API Key Approval", async ({ page }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // should show OIDC tab
       const oidcTab = page.getByRole("tab", { name: "OIDC" });
@@ -141,9 +143,11 @@ test.describe("Auth Scheme UI Behaviour", () => {
       await expect(apiKeyApproval).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
     });
 
-    test("should show OIDC Provider Discovery when clicking OIDC tab", async ({ page }) => {
+    test("should show OIDC Provider Discovery when clicking OIDC tab", async ({
+      page,
+    }) => {
       await page.goto(apiProductPath);
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // click on OIDC tab
       const oidcTab = page.getByRole("tab", { name: "OIDC" });
@@ -158,7 +162,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
   test.describe("Catalog Entity Page - API Keys Tab", () => {
     test("OIDC-only API should NOT show API Keys tab", async ({ page }) => {
       await page.goto("/catalog/default/api/gamestore-api");
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // wait for entity page to load
       const entityPage = page.locator("main");
@@ -172,7 +176,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("API Key-enabled API should show API Keys tab", async ({ page }) => {
       await page.goto("/catalog/default/api/toystore-api");
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // wait for entity page to load
       const entityPage = page.locator("main");
@@ -185,7 +189,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
     test("Mixed auth API should show API Keys tab", async ({ page }) => {
       await page.goto("/catalog/default/api/gamestore-admin");
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // wait for entity page to load
       const entityPage = page.locator("main");
@@ -198,9 +202,11 @@ test.describe("Auth Scheme UI Behaviour", () => {
   });
 
   test.describe("Catalog Entity Page - Kuadrant API Keys Card", () => {
-    test("OIDC-only API should NOT show Kuadrant API Keys card on Overview", async ({ page }) => {
+    test("OIDC-only API should NOT show Kuadrant API Keys card on Overview", async ({
+      page,
+    }) => {
       await page.goto("/catalog/default/api/gamestore-api");
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // wait for entity page to load
       const entityPage = page.locator("main");
@@ -212,9 +218,11 @@ test.describe("Auth Scheme UI Behaviour", () => {
       expect(cardVisible).toBe(false);
     });
 
-    test("API Key-enabled API should show Kuadrant API Keys card on Overview", async ({ page }) => {
+    test("API Key-enabled API should show Kuadrant API Keys card on Overview", async ({
+      page,
+    }) => {
       await page.goto("/catalog/default/api/toystore-api");
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // wait for entity page to load
       const entityPage = page.locator("main");

--- a/e2e-tests/playwright/e2e/kuadrant-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-happy-path.spec.ts
@@ -147,7 +147,9 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
 
     // verify API product appears in table (scope to table to avoid matching toast)
     const table = page.locator("table");
-    const apiProductRow = table.getByRole("link", { name: testData.displayName });
+    const apiProductRow = table.getByRole("link", {
+      name: testData.displayName,
+    });
     await expect(
       apiProductRow,
       "Created API should appear in table",
@@ -179,7 +181,9 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
     await common.dexQuickLogin("consumer1@kuadrant.local");
 
     await page.goto("/catalog/default/api/toystore-api");
-    await page.waitForURL(/\/catalog\/.*\/api\/toystore-api/, { timeout: TIMEOUTS.VERY_SLOW });
+    await page.waitForURL(/\/catalog\/.*\/api\/toystore-api/, {
+      timeout: TIMEOUTS.VERY_SLOW,
+    });
 
     // click API Keys tab
     const apiKeysTab = page.getByRole("tab", { name: /api keys/i });
@@ -375,5 +379,65 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
       breadcrumbLink,
       "Breadcrumb link should be visible",
     ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
+  });
+
+  test("9. consumer1 deletes their API key", async ({ page }) => {
+    const common = new Common(page);
+    await common.dexQuickLogin("consumer1@kuadrant.local");
+    await page.goto("/kuadrant/my-api-keys");
+    await waitForApiKeysPageReady(page);
+
+    // find the first row in the table
+    const firstRow = page.locator("table tbody tr").first();
+    await expect(
+      firstRow,
+      "Consumer should see at least one API key",
+    ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+
+    // click the delete button in the Actions column
+    const deleteButton = firstRow.getByRole("button", { name: /delete/i });
+    await expect(deleteButton, "Delete button should be visible").toBeVisible({
+      timeout: TIMEOUTS.DEFAULT,
+    });
+    await deleteButton.click();
+
+    // confirm deletion in dialog
+    const confirmDialog = page.getByRole("dialog");
+    await expect(
+      confirmDialog,
+      "Delete confirmation dialog should open",
+    ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
+
+    // verify dialog has expected title
+    const dialogTitle = confirmDialog.getByText(/delete api key/i);
+    await expect(
+      dialogTitle,
+      "Dialog should have 'Delete API Key' title",
+    ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
+
+    // click confirm button
+    const confirmButton = confirmDialog.getByRole("button", {
+      name: /delete/i,
+    });
+    await confirmButton.click();
+
+    // verify dialog closes
+    await expect(
+      confirmDialog,
+      "Delete dialog should close after confirmation",
+    ).not.toBeVisible({ timeout: TIMEOUTS.SLOW });
+
+    // verify success message appeared
+    const successMessage = page.getByText(/api key deleted/i);
+    await expect(successMessage, "Success message should appear").toBeVisible({
+      timeout: TIMEOUTS.DEFAULT,
+    });
+
+    // verify the key is removed — table should be empty after deleting the only key
+    const emptyState = page.getByText(/no api keys found/i);
+    await expect(
+      emptyState,
+      "Table should show empty state after deleting the only key",
+    ).toBeVisible({ timeout: TIMEOUTS.SLOW });
   });
 });

--- a/e2e-tests/playwright/e2e/kuadrant-permissions-matrix.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-permissions-matrix.spec.ts
@@ -84,7 +84,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.goto("/kuadrant/api-products");
       await waitForKuadrantPageReady(page);
 
-      const apiProductsSection = page.locator("h1").filter({ hasText: /api products/i });
+      const apiProductsSection = page
+        .locator("h1")
+        .filter({ hasText: /api products/i });
       await expect(
         apiProductsSection,
         "Admin should see API Products section",
@@ -99,7 +101,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.goto("/kuadrant/api-products");
       await waitForKuadrantPageReady(page);
 
-      const apiProductsSection = page.locator("h1").filter({ hasText: /api products/i });
+      const apiProductsSection = page
+        .locator("h1")
+        .filter({ hasText: /api products/i });
       await expect(
         apiProductsSection,
         "Owner should see API Products section",
@@ -114,7 +118,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.goto("/kuadrant/api-products");
       await waitForKuadrantPageReady(page);
 
-      const apiProductsSection = page.locator("h1").filter({ hasText: /api products/i });
+      const apiProductsSection = page
+        .locator("h1")
+        .filter({ hasText: /api products/i });
       await expect(
         apiProductsSection,
         "Consumer should see API Products section",
@@ -129,7 +135,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.goto("/kuadrant/api-products");
       await waitForKuadrantPageReady(page);
 
-      const apiProductsCard = page.locator("h1").filter({ hasText: /api products/i });
+      const apiProductsCard = page
+        .locator("h1")
+        .filter({ hasText: /api products/i });
       await expect(apiProductsCard).toBeVisible({ timeout: TIMEOUTS.SLOW });
 
       // admin should see edit icon on any row
@@ -160,7 +168,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
         .locator("tr")
         .filter({ hasText: "Gamestore API" })
         .first();
-      const gamestoreVisible = await gamestoreRow.isVisible().catch(() => false);
+      const gamestoreVisible = await gamestoreRow
+        .isVisible()
+        .catch(() => false);
 
       if (gamestoreVisible) {
         // owner1 should NOT see edit button on Gamestore API (owned by owner2)
@@ -182,7 +192,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.goto("/kuadrant/api-products");
       await waitForKuadrantPageReady(page);
 
-      const apiProductsCard = page.locator("h1").filter({ hasText: /api products/i });
+      const apiProductsCard = page
+        .locator("h1")
+        .filter({ hasText: /api products/i });
       await expect(apiProductsCard).toBeVisible({ timeout: TIMEOUTS.SLOW });
 
       // admin should see delete icon on any row
@@ -229,7 +241,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       const common = new Common(page);
       await common.dexQuickLogin("admin@kuadrant.local");
       await page.goto("/catalog/default/api/toystore-api");
-      await page.waitForURL(/\/catalog\/.*\/api\/toystore-api/, { timeout: TIMEOUTS.VERY_SLOW });
+      await page.waitForURL(/\/catalog\/.*\/api\/toystore-api/, {
+        timeout: TIMEOUTS.VERY_SLOW,
+      });
 
       const apiKeysTab = page.getByRole("tab", { name: /api keys/i });
       await expect(apiKeysTab, "API Keys tab should exist").toBeVisible({
@@ -252,7 +266,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await common.dexQuickLogin("owner1@kuadrant.local");
 
       await page.goto("/catalog/default/api/toystore-api");
-      await page.waitForURL(/\/catalog\/.*\/api\/toystore-api/, { timeout: TIMEOUTS.VERY_SLOW });
+      await page.waitForURL(/\/catalog\/.*\/api\/toystore-api/, {
+        timeout: TIMEOUTS.VERY_SLOW,
+      });
 
       const apiKeysTab = page.getByRole("tab", { name: /api keys/i });
       await expect(apiKeysTab, "API Keys tab should exist").toBeVisible({
@@ -275,7 +291,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await common.dexQuickLogin("consumer1@kuadrant.local");
 
       await page.goto("/catalog/default/api/toystore-api");
-      await page.waitForURL(/\/catalog\/.*\/api\/toystore-api/, { timeout: TIMEOUTS.VERY_SLOW });
+      await page.waitForURL(/\/catalog\/.*\/api\/toystore-api/, {
+        timeout: TIMEOUTS.VERY_SLOW,
+      });
 
       const apiKeysTab = page.getByRole("tab", { name: /api keys/i });
       await expect(apiKeysTab, "API Keys tab should exist").toBeVisible({
@@ -298,7 +316,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await common.dexQuickLogin("admin@kuadrant.local");
       await page.goto("/kuadrant/api-key-approval");
 
-      const heading = page.locator("h1, h2").filter({ hasText: /api key approval/i });
+      const heading = page
+        .locator("h1, h2")
+        .filter({ hasText: /api key approval/i });
       await expect(
         heading.first(),
         "Admin should see API Key Approval page",
@@ -312,7 +332,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await common.dexQuickLogin("owner1@kuadrant.local");
       await page.goto("/kuadrant/api-key-approval");
 
-      const heading = page.locator("h1, h2").filter({ hasText: /api key approval/i });
+      const heading = page
+        .locator("h1, h2")
+        .filter({ hasText: /api key approval/i });
       await expect(
         heading.first(),
         "Owner should see API Key Approval page",
@@ -333,7 +355,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.waitForTimeout(2000);
 
       // Consumer should NOT see "API Key Approval" heading
-      const approvalHeading = page.locator("h1, h2").filter({ hasText: /api key approval/i });
+      const approvalHeading = page
+        .locator("h1, h2")
+        .filter({ hasText: /api key approval/i });
       await expect(
         approvalHeading,
         "Consumer should NOT see API Key Approval page",
@@ -347,7 +371,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await common.dexQuickLogin("consumer1@kuadrant.local");
       await page.goto("/kuadrant/my-api-keys");
 
-      const heading = page.locator("h1, h2").filter({ hasText: /my api keys/i });
+      const heading = page
+        .locator("h1, h2")
+        .filter({ hasText: /my api keys/i });
       await expect(
         heading.first(),
         "Consumer should see My API Keys page",
@@ -361,7 +387,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await common.dexQuickLogin("consumer1@kuadrant.local");
       await page.goto("/kuadrant/my-api-keys");
 
-      const heading = page.locator("h1, h2").filter({ hasText: /my api keys/i });
+      const heading = page
+        .locator("h1, h2")
+        .filter({ hasText: /my api keys/i });
       await expect(heading.first()).toBeVisible({ timeout: TIMEOUTS.SLOW });
 
       // verify filter panel exists
@@ -469,7 +497,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await common.dexQuickLogin("admin@kuadrant.local");
       await page.goto("/kuadrant/api-key-approval");
 
-      const heading = page.locator("h1, h2").filter({ hasText: /api key approval/i });
+      const heading = page
+        .locator("h1, h2")
+        .filter({ hasText: /api key approval/i });
       await expect(
         heading.first(),
         "Admin should see API Key Approval page",
@@ -505,7 +535,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await waitForKuadrantPageReady(page);
 
       // wait for page to load
-      const apiProductsCard = page.locator("h1").filter({ hasText: /api products/i });
+      const apiProductsCard = page
+        .locator("h1")
+        .filter({ hasText: /api products/i });
       await expect(apiProductsCard).toBeVisible({ timeout: TIMEOUTS.SLOW });
 
       // consumer should not see any edit buttons
@@ -526,7 +558,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.goto("/kuadrant/api-products");
       await waitForKuadrantPageReady(page);
 
-      const apiProductsCard = page.locator("h1").filter({ hasText: /api products/i });
+      const apiProductsCard = page
+        .locator("h1")
+        .filter({ hasText: /api products/i });
       await expect(apiProductsCard).toBeVisible({ timeout: TIMEOUTS.SLOW });
 
       // consumer should not see any delete buttons in API products table
@@ -576,7 +610,10 @@ test.describe("Kuadrant Permissions Matrix", () => {
 
       // consumer should see Policy filter in the filter panel
       const policyFilter = page.locator("text=POLICY").first();
-      await expect(policyFilter, "Consumer should see Policy filter").toBeVisible({
+      await expect(
+        policyFilter,
+        "Consumer should see Policy filter",
+      ).toBeVisible({
         timeout: TIMEOUTS.DEFAULT,
       });
 

--- a/e2e-tests/playwright/e2e/kuadrant-plugin.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-plugin.spec.ts
@@ -37,9 +37,6 @@ test.describe("Kuadrant Plugin", () => {
       'nav a[href="/kuadrant/api-products"]',
     );
     const myApiKeysLink = page.locator('nav a[href="/kuadrant/my-api-keys"]');
-    const apiKeyApprovalLink = page.locator(
-      'nav a[href="/kuadrant/api-key-approval"]',
-    );
 
     await expect(apiProductsLink).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
     await expect(myApiKeysLink).toBeVisible({ timeout: TIMEOUTS.DEFAULT });

--- a/e2e-tests/playwright/e2e/kuadrant-request-access.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-request-access.spec.ts
@@ -169,13 +169,13 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     // verify tier options show limits (e.g., "bronze (10 per minute)")
     const tierListbox = page.getByRole("listbox");
     const tierWithLimits = tierListbox.getByRole("option").first();
-    const tierText = await tierWithLimits.textContent();
+    const tierText = tierWithLimits;
 
     // tier text should contain the tier name and optionally limits like "(10 per minute)"
-    expect(
+    await expect(
       tierText,
       "Tier option should show tier name and limits",
-    ).toBeTruthy();
+    ).toHaveText(/.+/);
   });
 
   test("should enable Submit button only when API and Tier are selected", async ({
@@ -250,8 +250,8 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await useCaseField.fill(testUseCase);
 
     // verify text was entered
-    const fieldValue = await useCaseField.inputValue();
-    expect(fieldValue).toBe(testUseCase);
+    const fieldValue = useCaseField;
+    await expect(fieldValue).toHaveValue(testUseCase);
   });
 
   test("should successfully submit a request and close dialog", async ({
@@ -380,8 +380,11 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
     const useCaseFieldReopened = dialog.getByTestId("usecase-input");
-    const fieldValue = await useCaseFieldReopened.inputValue();
-    expect(fieldValue, "Use case field should be empty after reset").toBe("");
+    const fieldValue = useCaseFieldReopened;
+    await expect(
+      fieldValue,
+      "Use case field should be empty after reset",
+    ).toHaveValue("");
   });
 
   test("should display helper text for fields", async ({ page }) => {

--- a/e2e-tests/playwright/e2e/kuadrant-skeleton-loaders.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-skeleton-loaders.spec.ts
@@ -142,8 +142,12 @@ test.describe("Kuadrant Skeleton Loaders", () => {
       // Wait for initial load
       await page.waitForLoadState("load").catch(() => {});
 
+      // Wait for global app loader to disappear (it uses CircularProgress but is app infrastructure)
+      // The loader is a centered, full-height box
+      await page.waitForTimeout(500); // Give the loader time to disappear
+
       // The Backstage Progress component renders as a CircularProgress with role="progressbar"
-      // but we want to make sure it's not being used for page-level loading
+      // but we want to make sure it's not being used for page-level loading in Kuadrant components
       // (it's still OK for inline operations like delete buttons)
 
       // Check that we're using skeletons OR the page is already loaded

--- a/e2e-tests/playwright/e2e/kuadrant-skeleton-loaders.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-skeleton-loaders.spec.ts
@@ -25,7 +25,7 @@ test.describe("Kuadrant Skeleton Loaders", () => {
 
     // Check for skeleton loaders (Material-UI Skeleton creates spans with specific classes)
     // We look for the MuiSkeleton class which is present during loading
-    const skeletons = page.locator('.MuiSkeleton-root');
+    const skeletons = page.locator(".MuiSkeleton-root");
 
     // Either skeletons are visible (still loading) or they're gone (loaded fast)
     // We can't guarantee we'll catch them, but if we do, they should be proper skeletons
@@ -37,8 +37,10 @@ test.describe("Kuadrant Skeleton Loaders", () => {
       await expect(firstSkeleton).toBeVisible();
 
       // Skeletons should have the text variant or rect variant class
-      const hasTextVariant = await firstSkeleton.evaluate((el) =>
-        el.classList.contains('MuiSkeleton-text') || el.classList.contains('MuiSkeleton-rect')
+      const hasTextVariant = await firstSkeleton.evaluate(
+        (el) =>
+          el.classList.contains("MuiSkeleton-text") ||
+          el.classList.contains("MuiSkeleton-rect"),
       );
       expect(hasTextVariant).toBe(true);
     }
@@ -49,7 +51,7 @@ test.describe("Kuadrant Skeleton Loaders", () => {
       await expect(spinner).toHaveCount(0);
 
       // No skeletons should be visible after loading
-      const visibleSkeletons = page.locator('.MuiSkeleton-root:visible');
+      const visibleSkeletons = page.locator(".MuiSkeleton-root:visible");
       await expect(visibleSkeletons).toHaveCount(0);
     }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
 
@@ -62,16 +64,16 @@ test.describe("Kuadrant Skeleton Loaders", () => {
     page,
   }) => {
     // Use network throttling to increase chance of catching skeletons
-    await page.route('**/api/kuadrant/apiproducts*', async (route) => {
+    await page.route("**/api/kuadrant/apiproducts*", async (route) => {
       // Delay the response slightly to make skeleton more visible
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       await route.continue();
     });
 
     await page.goto("/kuadrant/api-products");
 
     // Check for skeleton loaders during initial load
-    const skeletons = page.locator('.MuiSkeleton-root');
+    const skeletons = page.locator(".MuiSkeleton-root");
     const skeletonCount = await skeletons.count();
 
     if (skeletonCount > 0) {
@@ -83,7 +85,7 @@ test.describe("Kuadrant Skeleton Loaders", () => {
     await expect(async () => {
       const spinner = page.locator('[role="progressbar"]:visible');
       await expect(spinner).toHaveCount(0);
-      const visibleSkeletons = page.locator('.MuiSkeleton-root:visible');
+      const visibleSkeletons = page.locator(".MuiSkeleton-root:visible");
       await expect(visibleSkeletons).toHaveCount(0);
     }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
 
@@ -97,11 +99,13 @@ test.describe("Kuadrant Skeleton Loaders", () => {
   }) => {
     // Navigate to catalog and wait for it to load
     await page.goto("/catalog?filters[kind]=api");
-    await page.waitForLoadState("networkidle").catch(() => {});
+    await page.waitForLoadState("load").catch(() => {});
 
     // Wait for catalog to be ready
     await expect(async () => {
-      const catalogHeading = page.locator("h1, h2").filter({ hasText: /catalog/i });
+      const catalogHeading = page
+        .locator("h1, h2")
+        .filter({ hasText: /catalog/i });
       await expect(catalogHeading.first()).toBeVisible();
     }).toPass({ timeout: TIMEOUTS.SLOW });
 
@@ -112,12 +116,9 @@ test.describe("Kuadrant Skeleton Loaders", () => {
     if (hasApiLink > 0) {
       await apiLink.click();
 
-      // The ApiAccessCard might show skeletons while loading
-      const skeletons = page.locator('.MuiSkeleton-root');
-
       // Eventually page should be fully loaded without skeletons
       await expect(async () => {
-        const visibleSkeletons = page.locator('.MuiSkeleton-root:visible');
+        const visibleSkeletons = page.locator(".MuiSkeleton-root:visible");
         await expect(visibleSkeletons).toHaveCount(0);
       }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
 
@@ -139,7 +140,7 @@ test.describe("Kuadrant Skeleton Loaders", () => {
       await page.goto(url);
 
       // Wait for initial load
-      await page.waitForLoadState("networkidle").catch(() => {});
+      await page.waitForLoadState("load").catch(() => {});
 
       // The Backstage Progress component renders as a CircularProgress with role="progressbar"
       // but we want to make sure it's not being used for page-level loading
@@ -148,7 +149,7 @@ test.describe("Kuadrant Skeleton Loaders", () => {
       // Check that we're using skeletons OR the page is already loaded
       await expect(async () => {
         const progressBars = page.locator('[role="progressbar"]:visible');
-        const skeletons = page.locator('.MuiSkeleton-root:visible');
+        const skeletons = page.locator(".MuiSkeleton-root:visible");
         const progressCount = await progressBars.count();
         const skeletonCount = await skeletons.count();
 
@@ -157,7 +158,7 @@ test.describe("Kuadrant Skeleton Loaders", () => {
         if (progressCount > 0 && skeletonCount === 0) {
           // Only acceptable if it's a small inline spinner (like in a button)
           const isInButton = await progressBars.first().evaluate((el) => {
-            return el.closest('button') !== null;
+            return el.closest("button") !== null;
           });
           expect(isInButton).toBe(true);
         }
@@ -170,7 +171,7 @@ test.describe("Kuadrant Skeleton Loaders", () => {
   }) => {
     // First, navigate to API Products list to find a valid product
     await page.goto("/kuadrant/api-products");
-    await page.waitForLoadState("networkidle").catch(() => {});
+    await page.waitForLoadState("load").catch(() => {});
 
     // Wait for page to load
     await expect(async () => {
@@ -179,19 +180,18 @@ test.describe("Kuadrant Skeleton Loaders", () => {
     }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
 
     // Try to find a link to an API Product detail page
-    const productLink = page.locator('a[href*="/kuadrant/api-products/"]').first();
+    const productLink = page
+      .locator('a[href*="/kuadrant/api-products/"]')
+      .first();
     const hasProductLink = await productLink.count();
 
     if (hasProductLink > 0) {
       // Click to navigate to detail page
       await productLink.click();
 
-      // Check for skeletons during load
-      const skeletons = page.locator('.MuiSkeleton-root');
-
       // Wait for full load
       await expect(async () => {
-        const visibleSkeletons = page.locator('.MuiSkeleton-root:visible');
+        const visibleSkeletons = page.locator(".MuiSkeleton-root:visible");
         await expect(visibleSkeletons).toHaveCount(0);
       }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
 

--- a/e2e-tests/playwright/e2e/smoke-test.spec.ts
+++ b/e2e-tests/playwright/e2e/smoke-test.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { UIhelper } from "../utils/ui-helper";
 import { Common } from "../utils/common";
 test.describe("Smoke test", () => {
-  let uiHelper: UIhelper;
   let common: Common;
 
   test.beforeAll(async () => {
@@ -13,7 +11,6 @@ test.describe("Smoke test", () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    uiHelper = new UIhelper(page);
     common = new Common(page);
     await common.loginAsGuest();
   });
@@ -21,7 +18,9 @@ test.describe("Smoke test", () => {
   test("Verify the Homepage renders", async ({ page }) => {
     // in production mode (yarn start), dynamic home page shows "welcome back!"
     // in dev mode (yarn dev), home redirects to catalog which shows "my org catalog"
-    const homeHeading = page.locator('h1, h2, h3, h4, h5, h6').filter({ hasText: /Welcome back!|My Org Catalog/i });
+    const homeHeading = page
+      .locator("h1, h2, h3, h4, h5, h6")
+      .filter({ hasText: /Welcome back!|My Org Catalog/i });
     await expect(homeHeading.first()).toBeVisible({ timeout: 20000 });
   });
 });

--- a/e2e-tests/playwright/utils/common.ts
+++ b/e2e-tests/playwright/utils/common.ts
@@ -474,7 +474,9 @@ export class Common {
 
     // extract role from email (e.g., "owner1@kuadrant.local" -> "owner1")
     const role = userEmail.split("@")[0];
-    const quickLoginButton = popup.locator(`[data-testid="quick-login-${role}"]`);
+    const quickLoginButton = popup.locator(
+      `[data-testid="quick-login-${role}"]`,
+    );
     await quickLoginButton.click({ timeout: 10000 });
     await popup.waitForEvent("close", { timeout: 10000 });
 

--- a/e2e-tests/playwright/utils/kuadrant-helpers.ts
+++ b/e2e-tests/playwright/utils/kuadrant-helpers.ts
@@ -122,7 +122,7 @@ export async function waitForKuadrantPageReady(page: Page): Promise<void> {
   await page.waitForURL(/\/kuadrant\/api-products/, {
     timeout: TIMEOUTS.VERY_SLOW,
   });
-  await page.waitForLoadState("networkidle").catch(() => {});
+  await page.waitForLoadState("load").catch(() => {});
 
   await expect(async () => {
     // no visible spinners
@@ -150,7 +150,7 @@ export async function waitForApiKeysPageReady(
   headingPattern: RegExp = /api key/i,
 ): Promise<void> {
   await page.waitForURL(urlPattern, { timeout: TIMEOUTS.VERY_SLOW });
-  await page.waitForLoadState("networkidle").catch(() => {});
+  await page.waitForLoadState("load").catch(() => {});
 
   await expect(async () => {
     // no visible spinners

--- a/packages/app/src/components/AppBase/AppBase.tsx
+++ b/packages/app/src/components/AppBase/AppBase.tsx
@@ -154,13 +154,7 @@ const AppBase = () => {
               <Route path="/kuadrant/my-api-keys" element={<MyApiKeysPage />} />
               <Route
                 path="/kuadrant/api-key-approval"
-                element={
-                  <RequirePermission
-                    permission={kuadrantApiKeyApprovePermission}
-                  >
-                    <ApiKeyApprovalPage />
-                  </RequirePermission>
-                }
+                element={<ApiKeyApprovalPage />}
               />
               <Route
                 path="/kuadrant/api-keys/:namespace/:name"

--- a/packages/app/src/components/AppBase/AppBase.tsx
+++ b/packages/app/src/components/AppBase/AppBase.tsx
@@ -26,7 +26,6 @@ import {
   ApiKeyDetailPage,
   ApiProductDetailPage,
   ApiProductsPage,
-  kuadrantApiKeyApprovePermission,
   MyApiKeysPage,
 } from '@kuadrant/kuadrant-backstage-plugin-frontend';
 import DynamicRootContext from '@red-hat-developer-hub/plugin-utils';

--- a/plugins/kuadrant-backend/src/router.test.ts
+++ b/plugins/kuadrant-backend/src/router.test.ts
@@ -1108,6 +1108,190 @@ describe('createRouter', () => {
     });
   });
 
+  describe('DELETE /requests/:namespace/:name', () => {
+    const consumerNamespace = 'kuadrant-consumer-abc123';
+    const apiKeyName = 'toystore-api-abc123';
+    const ownerNamespace = 'toystore';
+
+    const mockAPIKey = {
+      apiVersion: 'devportal.kuadrant.io/v1alpha1',
+      kind: 'APIKey',
+      metadata: {
+        name: apiKeyName,
+        namespace: consumerNamespace,
+      },
+      spec: {
+        apiProductRef: {
+          name: 'toystore-api',
+          namespace: ownerNamespace,
+        },
+        planTier: 'gold',
+        useCase: 'Testing API integration',
+        requestedBy: {
+          userId: mockUserEntityRef,
+          email: 'testuser@example.com',
+        },
+        secretRef: {
+          name: 'testuser-toystore-secret',
+        },
+      },
+      status: { conditions: [] },
+    };
+
+    const mockOtherUserAPIKey = {
+      ...mockAPIKey,
+      spec: {
+        ...mockAPIKey.spec,
+        requestedBy: {
+          userId: mockOtherUserEntityRef,
+          email: 'otheruser@example.com',
+        },
+      },
+    };
+
+    const mockAPIProduct = {
+      apiVersion: 'devportal.kuadrant.io/v1alpha1',
+      kind: 'APIProduct',
+      metadata: {
+        name: 'toystore-api',
+        namespace: ownerNamespace,
+        annotations: {
+          'backstage.io/owner': mockUserEntityRef,
+        },
+      },
+      spec: {},
+    };
+
+    const mockOtherAPIProduct = {
+      ...mockAPIProduct,
+      metadata: {
+        ...mockAPIProduct.metadata,
+        annotations: {
+          'backstage.io/owner': mockOtherUserEntityRef,
+        },
+      },
+    };
+
+    it('allows consumer to delete their own APIKey', async () => {
+      // deleteAll denied, deleteOwn allowed
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ]);
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ]);
+
+      mockK8sClient.getCustomResource.mockResolvedValueOnce(mockAPIKey);
+      mockK8sClient.deleteCustomResource.mockResolvedValueOnce({} as any);
+
+      await request(app)
+        .delete(`/requests/${consumerNamespace}/${apiKeyName}`)
+        .expect(204);
+
+      expect(mockK8sClient.deleteCustomResource).toHaveBeenCalledWith(
+        'devportal.kuadrant.io',
+        'v1alpha1',
+        consumerNamespace,
+        'apikeys',
+        apiKeyName,
+      );
+    });
+
+    it('allows owner to delete APIKey for their own API product', async () => {
+      // deleteAll denied, deleteOwn allowed
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ]);
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ]);
+
+      // APIKey belongs to other user, but testuser owns the API product
+      mockK8sClient.getCustomResource
+        .mockResolvedValueOnce(mockOtherUserAPIKey) // fetch APIKey
+        .mockResolvedValueOnce(mockAPIProduct); // fetch APIProduct — owned by testuser
+      mockK8sClient.deleteCustomResource.mockResolvedValueOnce({} as any);
+
+      await request(app)
+        .delete(`/requests/${consumerNamespace}/${apiKeyName}`)
+        .expect(204);
+
+      expect(mockK8sClient.deleteCustomResource).toHaveBeenCalledWith(
+        'devportal.kuadrant.io',
+        'v1alpha1',
+        consumerNamespace,
+        'apikeys',
+        apiKeyName,
+      );
+    });
+
+    it('allows admin to delete any APIKey', async () => {
+      // deleteAll allowed
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ]);
+
+      mockK8sClient.getCustomResource.mockResolvedValueOnce(mockOtherUserAPIKey);
+      mockK8sClient.deleteCustomResource.mockResolvedValueOnce({} as any);
+
+      await request(app)
+        .delete(`/requests/${consumerNamespace}/${apiKeyName}`)
+        .expect(204);
+
+      expect(mockK8sClient.deleteCustomResource).toHaveBeenCalledWith(
+        'devportal.kuadrant.io',
+        'v1alpha1',
+        consumerNamespace,
+        'apikeys',
+        apiKeyName,
+      );
+
+      // admin path should NOT fetch APIProduct for ownership
+      expect(mockK8sClient.getCustomResource).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 403 when consumer tries to delete another users APIKey', async () => {
+      // deleteAll denied, deleteOwn allowed
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ]);
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ]);
+
+      // APIKey belongs to other user, API product also owned by other user
+      mockK8sClient.getCustomResource
+        .mockResolvedValueOnce(mockOtherUserAPIKey) // fetch APIKey
+        .mockResolvedValueOnce(mockOtherAPIProduct); // fetch APIProduct — owned by otheruser
+
+      const response = await request(app)
+        .delete(`/requests/${consumerNamespace}/${apiKeyName}`)
+        .expect(403);
+
+      expect(response.body.error).toContain('you can only delete');
+      expect(mockK8sClient.deleteCustomResource).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when user has no delete permissions', async () => {
+      // deleteAll denied, deleteOwn denied
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ]);
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ]);
+
+      mockK8sClient.getCustomResource.mockResolvedValueOnce(mockAPIKey);
+
+      const response = await request(app)
+        .delete(`/requests/${consumerNamespace}/${apiKeyName}`)
+        .expect(403);
+
+      expect(response.body.error).toBe('unauthorised');
+      expect(mockK8sClient.deleteCustomResource).not.toHaveBeenCalled();
+    });
+  });
+
   describe('PATCH /apiproducts/:namespace/:name', () => {
     const namespace = 'toystore';
     const name = 'toystore-api';

--- a/plugins/kuadrant-backend/src/router.test.ts
+++ b/plugins/kuadrant-backend/src/router.test.ts
@@ -1315,7 +1315,6 @@ describe('createRouter', () => {
   describe('DELETE /requests/:namespace/:name', () => {
     const consumerNamespace = 'kuadrant-consumer-abc123';
     const apiKeyName = 'toystore-api-abc123';
-    const ownerNamespace = 'toystore';
 
     const mockAPIKey = {
       apiVersion: 'devportal.kuadrant.io/v1alpha1',
@@ -1327,7 +1326,7 @@ describe('createRouter', () => {
       spec: {
         apiProductRef: {
           name: 'toystore-api',
-          namespace: ownerNamespace,
+          namespace: 'toystore',
         },
         planTier: 'gold',
         useCase: 'Testing API integration',
@@ -1353,34 +1352,7 @@ describe('createRouter', () => {
       },
     };
 
-    const mockAPIProduct = {
-      apiVersion: 'devportal.kuadrant.io/v1alpha1',
-      kind: 'APIProduct',
-      metadata: {
-        name: 'toystore-api',
-        namespace: ownerNamespace,
-        annotations: {
-          'backstage.io/owner': mockUserEntityRef,
-        },
-      },
-      spec: {},
-    };
-
-    const mockOtherAPIProduct = {
-      ...mockAPIProduct,
-      metadata: {
-        ...mockAPIProduct.metadata,
-        annotations: {
-          'backstage.io/owner': mockOtherUserEntityRef,
-        },
-      },
-    };
-
     it('allows consumer to delete their own APIKey', async () => {
-      // deleteAll denied, deleteOwn allowed
-      mockAuthorizeFn.mockResolvedValueOnce([
-        { result: AuthorizeResult.DENY },
-      ]);
       mockAuthorizeFn.mockResolvedValueOnce([
         { result: AuthorizeResult.ALLOW },
       ]);
@@ -1401,72 +1373,12 @@ describe('createRouter', () => {
       );
     });
 
-    it('allows owner to delete APIKey for their own API product', async () => {
-      // deleteAll denied, deleteOwn allowed
-      mockAuthorizeFn.mockResolvedValueOnce([
-        { result: AuthorizeResult.DENY },
-      ]);
-      mockAuthorizeFn.mockResolvedValueOnce([
-        { result: AuthorizeResult.ALLOW },
-      ]);
-
-      // APIKey belongs to other user, but testuser owns the API product
-      mockK8sClient.getCustomResource
-        .mockResolvedValueOnce(mockOtherUserAPIKey) // fetch APIKey
-        .mockResolvedValueOnce(mockAPIProduct); // fetch APIProduct — owned by testuser
-      mockK8sClient.deleteCustomResource.mockResolvedValueOnce({} as any);
-
-      await request(app)
-        .delete(`/requests/${consumerNamespace}/${apiKeyName}`)
-        .expect(204);
-
-      expect(mockK8sClient.deleteCustomResource).toHaveBeenCalledWith(
-        'devportal.kuadrant.io',
-        'v1alpha1',
-        consumerNamespace,
-        'apikeys',
-        apiKeyName,
-      );
-    });
-
-    it('allows admin to delete any APIKey', async () => {
-      // deleteAll allowed
+    it('returns 403 when consumer tries to delete another users APIKey', async () => {
       mockAuthorizeFn.mockResolvedValueOnce([
         { result: AuthorizeResult.ALLOW },
       ]);
 
       mockK8sClient.getCustomResource.mockResolvedValueOnce(mockOtherUserAPIKey);
-      mockK8sClient.deleteCustomResource.mockResolvedValueOnce({} as any);
-
-      await request(app)
-        .delete(`/requests/${consumerNamespace}/${apiKeyName}`)
-        .expect(204);
-
-      expect(mockK8sClient.deleteCustomResource).toHaveBeenCalledWith(
-        'devportal.kuadrant.io',
-        'v1alpha1',
-        consumerNamespace,
-        'apikeys',
-        apiKeyName,
-      );
-
-      // admin path should NOT fetch APIProduct for ownership
-      expect(mockK8sClient.getCustomResource).toHaveBeenCalledTimes(1);
-    });
-
-    it('returns 403 when consumer tries to delete another users APIKey', async () => {
-      // deleteAll denied, deleteOwn allowed
-      mockAuthorizeFn.mockResolvedValueOnce([
-        { result: AuthorizeResult.DENY },
-      ]);
-      mockAuthorizeFn.mockResolvedValueOnce([
-        { result: AuthorizeResult.ALLOW },
-      ]);
-
-      // APIKey belongs to other user, API product also owned by other user
-      mockK8sClient.getCustomResource
-        .mockResolvedValueOnce(mockOtherUserAPIKey) // fetch APIKey
-        .mockResolvedValueOnce(mockOtherAPIProduct); // fetch APIProduct — owned by otheruser
 
       const response = await request(app)
         .delete(`/requests/${consumerNamespace}/${apiKeyName}`)
@@ -1477,10 +1389,6 @@ describe('createRouter', () => {
     });
 
     it('returns 403 when user has no delete permissions', async () => {
-      // deleteAll denied, deleteOwn denied
-      mockAuthorizeFn.mockResolvedValueOnce([
-        { result: AuthorizeResult.DENY },
-      ]);
       mockAuthorizeFn.mockResolvedValueOnce([
         { result: AuthorizeResult.DENY },
       ]);

--- a/plugins/kuadrant-backend/src/router.test.ts
+++ b/plugins/kuadrant-backend/src/router.test.ts
@@ -1108,6 +1108,210 @@ describe('createRouter', () => {
     });
   });
 
+  describe('GET /requests', () => {
+    const namespace = 'toystore';
+
+    const createMockAPIKeyRequest = (name: string, apiProductName: string, status: string) => ({
+      apiVersion: 'devportal.kuadrant.io/v1alpha1',
+      kind: 'APIKeyRequest',
+      metadata: { name, namespace, creationTimestamp: '2024-12-02T10:00:00Z' },
+      spec: {
+        apiProductRef: { name: apiProductName },
+        apiKeyRef: { name: `${name}-apikey`, namespace: 'consumer-ns' },
+        planTier: 'gold',
+        useCase: 'Testing',
+        requestedBy: { userId: 'user:default/consumer', email: 'consumer@example.com' },
+      },
+      status: {
+        conditions: status === 'Approved' ? [{ type: 'Approved', status: 'True' }]
+          : status === 'Denied' ? [{ type: 'Denied', status: 'True' }]
+          : [],
+      },
+    });
+
+    const mockAPIProduct = {
+      apiVersion: 'devportal.kuadrant.io/v1alpha1',
+      kind: 'APIProduct',
+      metadata: {
+        name: 'toystore-api',
+        namespace,
+        annotations: { 'backstage.io/owner': mockUserEntityRef },
+      },
+      spec: {},
+    };
+
+    it('lists apikeyrequests with correct CRD and namespace', async () => {
+      // readAll allowed
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+
+      mockK8sClient.listCustomResources.mockResolvedValueOnce({
+        items: [createMockAPIKeyRequest('req-1', 'toystore-api', 'Pending')],
+      });
+
+      const response = await request(app)
+        .get(`/requests?namespace=${namespace}`)
+        .expect(200);
+
+      expect(mockK8sClient.listCustomResources).toHaveBeenCalledWith(
+        'devportal.kuadrant.io',
+        'v1alpha1',
+        'apikeyrequests',
+        namespace,
+      );
+      expect(response.body.items).toHaveLength(1);
+    });
+
+    it('lists all apikeyrequests cluster-wide when no namespace provided', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+
+      mockK8sClient.listCustomResources.mockResolvedValueOnce({ items: [] });
+
+      await request(app).get('/requests').expect(200);
+
+      expect(mockK8sClient.listCustomResources).toHaveBeenCalledWith(
+        'devportal.kuadrant.io',
+        'v1alpha1',
+        'apikeyrequests',
+      );
+    });
+
+    it('filters by owned API products when user has readOwn permission', async () => {
+      // readAll denied, readOwn allowed
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.DENY }]);
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+
+      mockK8sClient.listCustomResources
+        .mockResolvedValueOnce({
+          items: [
+            createMockAPIKeyRequest('req-1', 'toystore-api', 'Pending'),
+            createMockAPIKeyRequest('req-2', 'other-api', 'Pending'),
+          ],
+        })
+        .mockResolvedValueOnce({
+          items: [mockAPIProduct],
+        });
+
+      const response = await request(app).get('/requests').expect(200);
+
+      // only req-1 returned (toystore-api owned by testuser)
+      expect(response.body.items).toHaveLength(1);
+      expect(response.body.items[0].metadata.name).toBe('req-1');
+    });
+
+    it('filters by status', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+
+      mockK8sClient.listCustomResources.mockResolvedValueOnce({
+        items: [
+          createMockAPIKeyRequest('req-approved', 'toystore-api', 'Approved'),
+          createMockAPIKeyRequest('req-pending', 'toystore-api', 'Pending'),
+          createMockAPIKeyRequest('req-denied', 'toystore-api', 'Denied'),
+        ],
+      });
+
+      const response = await request(app)
+        .get('/requests?status=Approved')
+        .expect(200);
+
+      expect(response.body.items).toHaveLength(1);
+      expect(response.body.items[0].metadata.name).toBe('req-approved');
+    });
+
+    it('returns 403 when user has no read permissions', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.DENY }]);
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.DENY }]);
+
+      const response = await request(app).get('/requests').expect(403);
+      expect(response.body.error).toBe('unauthorised');
+    });
+  });
+
+  describe('GET /requests/my', () => {
+    const createMockAPIKey = (name: string, apiProductName: string, apiProductNamespace: string, userId: string) => ({
+      apiVersion: 'devportal.kuadrant.io/v1alpha1',
+      kind: 'APIKey',
+      metadata: { name, namespace: 'kuadrant-testuser-c7a65229', creationTimestamp: '2024-12-02T10:00:00Z' },
+      spec: {
+        apiProductRef: { name: apiProductName, namespace: apiProductNamespace },
+        planTier: 'gold',
+        useCase: 'Testing',
+        requestedBy: { userId, email: 'test@example.com' },
+        secretRef: { name: `${name}-secret` },
+      },
+      status: { conditions: [] },
+    });
+
+    it('lists apikeys from derived consumer namespace with correct CRD', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+
+      mockK8sClient.listCustomResources.mockResolvedValueOnce({
+        items: [createMockAPIKey('key-1', 'toystore-api', 'toystore', mockUserEntityRef)],
+      });
+
+      const response = await request(app).get('/requests/my').expect(200);
+
+      // verify correct CRD plural and derived consumer namespace (not a query param)
+      const listCall = mockK8sClient.listCustomResources.mock.calls[0];
+      expect(listCall[0]).toBe('devportal.kuadrant.io');
+      expect(listCall[1]).toBe('v1alpha1');
+      expect(listCall[2]).toBe('apikeys');
+      expect(listCall[3]).toMatch(/^kuadrant-testuser-/);
+
+      expect(response.body.items).toHaveLength(1);
+    });
+
+    it('filters items by authenticated user identity', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+
+      mockK8sClient.listCustomResources.mockResolvedValueOnce({
+        items: [
+          createMockAPIKey('key-own', 'toystore-api', 'toystore', mockUserEntityRef),
+          createMockAPIKey('key-other', 'toystore-api', 'toystore', mockOtherUserEntityRef),
+        ],
+      });
+
+      const response = await request(app).get('/requests/my').expect(200);
+
+      expect(response.body.items).toHaveLength(1);
+      expect(response.body.items[0].metadata.name).toBe('key-own');
+    });
+
+    it('filters by apiProductName and apiProductNamespace', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+
+      mockK8sClient.listCustomResources.mockResolvedValueOnce({
+        items: [
+          createMockAPIKey('key-toystore', 'toystore-api', 'toystore', mockUserEntityRef),
+          createMockAPIKey('key-petstore', 'petstore-api', 'petstore', mockUserEntityRef),
+        ],
+      });
+
+      const response = await request(app)
+        .get('/requests/my?apiProductName=toystore-api&apiProductNamespace=toystore')
+        .expect(200);
+
+      expect(response.body.items).toHaveLength(1);
+      expect(response.body.items[0].metadata.name).toBe('key-toystore');
+    });
+
+    it('returns empty array when consumer namespace does not exist', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+
+      const error404 = new Error('404 not found');
+      mockK8sClient.listCustomResources.mockRejectedValueOnce(error404);
+
+      const response = await request(app).get('/requests/my').expect(200);
+      expect(response.body.items).toEqual([]);
+    });
+
+    it('returns 403 when user has no read permissions', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.DENY }]);
+
+      const response = await request(app).get('/requests/my').expect(403);
+      expect(response.body.error).toBe('unauthorised');
+    });
+  });
+
   describe('DELETE /requests/:namespace/:name', () => {
     const consumerNamespace = 'kuadrant-consumer-abc123';
     const apiKeyName = 'toystore-api-abc123';

--- a/plugins/kuadrant-backend/src/router.ts
+++ b/plugins/kuadrant-backend/src/router.ts
@@ -1473,8 +1473,8 @@ export async function createRouter({
       const { userEntityRef } = await getUserIdentity(req, httpAuth, userInfo);
       const { namespace, name } = req.params;
 
-      // get request to verify ownership
-      const request = await k8sClient.getCustomResource(
+      // get the APIKey to verify ownership
+      const apiKey = await k8sClient.getCustomResource(
         'devportal.kuadrant.io',
         'v1alpha1',
         namespace,
@@ -1482,9 +1482,7 @@ export async function createRouter({
         name,
       );
 
-      const requestUserId = request.spec?.requestedBy?.userId;
-
-      // check if user can delete all requests or just their own
+      // check if user can delete all requests (admin)
       const deleteAllDecision = await permissions.authorize(
         [{ permission: kuadrantApiKeyDeleteAllPermission }],
         { credentials }
@@ -1503,13 +1501,40 @@ export async function createRouter({
           throw new NotAllowedError('unauthorised');
         }
 
-        // verify ownership
-        if (requestUserId !== userEntityRef) {
-          throw new NotAllowedError('you can only delete your own api key requests');
+        const requestUserId = apiKey.spec?.requestedBy?.userId;
+
+        if (requestUserId === userEntityRef) {
+          // consumer deleting their own key — allowed
+        } else {
+          // check if user owns the referenced APIProduct
+          const apiProductName = apiKey.spec?.apiProductRef?.name;
+          const apiProductNamespace = apiKey.spec?.apiProductRef?.namespace;
+
+          if (!apiProductName || !apiProductNamespace) {
+            throw new NotAllowedError('cannot verify ownership: APIKey has no apiProductRef');
+          }
+
+          let apiProduct;
+          try {
+            apiProduct = await k8sClient.getCustomResource(
+              'devportal.kuadrant.io',
+              'v1alpha1',
+              apiProductNamespace,
+              'apiproducts',
+              apiProductName,
+            );
+          } catch (error) {
+            throw new NotAllowedError(`cannot verify ownership: APIProduct '${apiProductName}' not found`);
+          }
+
+          const owner = apiProduct.metadata?.annotations?.['backstage.io/owner'];
+          if (owner !== userEntityRef) {
+            throw new NotAllowedError('you can only delete your own api keys or keys for api products you own');
+          }
         }
       }
 
-      // controller owns the Secret via OwnerReference - it will be garbage collected
+      // delete the APIKey — controller handles cascade cleanup
       await k8sClient.deleteCustomResource(
         'devportal.kuadrant.io',
         'v1alpha1',

--- a/plugins/kuadrant-backend/src/router.ts
+++ b/plugins/kuadrant-backend/src/router.ts
@@ -28,7 +28,6 @@ import {
   kuadrantApiKeyUpdateOwnPermission,
   kuadrantApiKeyUpdateAllPermission,
   kuadrantApiKeyDeleteOwnPermission,
-  kuadrantApiKeyDeleteAllPermission,
   kuadrantAuthPolicyListPermission,
   kuadrantRateLimitPolicyListPermission,
 } from './permissions';
@@ -1482,56 +1481,18 @@ export async function createRouter({
         name,
       );
 
-      // check if user can delete all requests (admin)
-      const deleteAllDecision = await permissions.authorize(
-        [{ permission: kuadrantApiKeyDeleteAllPermission }],
+      const deleteOwnDecision = await permissions.authorize(
+        [{ permission: kuadrantApiKeyDeleteOwnPermission }],
         { credentials }
       );
 
-      const canDeleteAll = deleteAllDecision[0].result === AuthorizeResult.ALLOW;
+      if (deleteOwnDecision[0].result !== AuthorizeResult.ALLOW) {
+        throw new NotAllowedError('unauthorised');
+      }
 
-      if (!canDeleteAll) {
-        // check if user can delete their own requests
-        const deleteOwnDecision = await permissions.authorize(
-          [{ permission: kuadrantApiKeyDeleteOwnPermission }],
-          { credentials }
-        );
-
-        if (deleteOwnDecision[0].result !== AuthorizeResult.ALLOW) {
-          throw new NotAllowedError('unauthorised');
-        }
-
-        const requestUserId = apiKey.spec?.requestedBy?.userId;
-
-        if (requestUserId === userEntityRef) {
-          // consumer deleting their own key — allowed
-        } else {
-          // check if user owns the referenced APIProduct
-          const apiProductName = apiKey.spec?.apiProductRef?.name;
-          const apiProductNamespace = apiKey.spec?.apiProductRef?.namespace;
-
-          if (!apiProductName || !apiProductNamespace) {
-            throw new NotAllowedError('cannot verify ownership: APIKey has no apiProductRef');
-          }
-
-          let apiProduct;
-          try {
-            apiProduct = await k8sClient.getCustomResource(
-              'devportal.kuadrant.io',
-              'v1alpha1',
-              apiProductNamespace,
-              'apiproducts',
-              apiProductName,
-            );
-          } catch (error) {
-            throw new NotAllowedError(`cannot verify ownership: APIProduct '${apiProductName}' not found`);
-          }
-
-          const owner = apiProduct.metadata?.annotations?.['backstage.io/owner'];
-          if (owner !== userEntityRef) {
-            throw new NotAllowedError('you can only delete your own api keys or keys for api products you own');
-          }
-        }
+      const requestUserId = apiKey.spec?.requestedBy?.userId;
+      if (requestUserId !== userEntityRef) {
+        throw new NotAllowedError('you can only delete your own api key requests');
       }
 
       // delete the APIKey — controller handles cascade cleanup

--- a/plugins/kuadrant/src/components/ApiKeyApprovalPage/ApiKeyApprovalPageWithPermissions.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyApprovalPage/ApiKeyApprovalPageWithPermissions.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { ApiKeyApprovalPage } from './ApiKeyApprovalPage';
+import { PermissionGate } from '../PermissionGate';
+import { kuadrantApiKeyApprovePermission } from '../../permissions';
+
+export const ApiKeyApprovalPageWithPermissions = () => {
+  return (
+    <PermissionGate
+      permission={kuadrantApiKeyApprovePermission}
+      errorMessage="You don't have permission to approve API keys"
+    >
+      <ApiKeyApprovalPage />
+    </PermissionGate>
+  );
+};

--- a/plugins/kuadrant/src/components/ApiKeyApprovalPage/index.ts
+++ b/plugins/kuadrant/src/components/ApiKeyApprovalPage/index.ts
@@ -1,1 +1,2 @@
 export { ApiKeyApprovalPage } from './ApiKeyApprovalPage';
+export { ApiKeyApprovalPageWithPermissions } from './ApiKeyApprovalPageWithPermissions';

--- a/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
@@ -279,15 +279,10 @@ export const ApiKeyManagementTab = ({
 
   const handleDeleteConfirm = async () => {
     if (!deleteDialogState.request) return;
-    const apiKeyRef = deleteDialogState.request.spec?.apiKeyRef;
-    if (apiKeyRef) {
-      await handleDeleteRequest(apiKeyRef.namespace, apiKeyRef.name);
-    } else {
-      await handleDeleteRequest(
-        deleteDialogState.request.metadata.namespace,
-        deleteDialogState.request.metadata.name,
-      );
-    }
+    await handleDeleteRequest(
+      deleteDialogState.request.metadata.namespace,
+      deleteDialogState.request.metadata.name,
+    );
     setDeleteDialogState({ open: false, request: null });
   };
 

--- a/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
@@ -172,12 +172,12 @@ export const ApiKeyManagementTab = ({
     error: updateRequestPermissionError,
   } = useKuadrantPermission(kuadrantApiKeyUpdateOwnPermission);
 
-  const handleDeleteRequest = async (requestNamespace: string, name: string) => {
+  const handleDeleteRequest = async (deleteNamespace: string, deleteName: string) => {
     // optimistic update - remove from UI immediately
-    setOptimisticallyDeleted((prev) => new Set(prev).add(name));
-    setDeleting(name);
+    setOptimisticallyDeleted((prev) => new Set(prev).add(deleteName));
+    setDeleting(deleteName);
     try {
-      await kuadrantApi.deleteRequest(requestNamespace, name);
+      await kuadrantApi.deleteRequest(deleteNamespace, deleteName);
       alertApi.post({
         message: "API key deleted successfully",
         severity: "success",
@@ -190,7 +190,7 @@ export const ApiKeyManagementTab = ({
       // rollback optimistic update on error
       setOptimisticallyDeleted((prev) => {
         const next = new Set(prev);
-        next.delete(name);
+        next.delete(deleteName);
         return next;
       });
       alertApi.post({
@@ -279,7 +279,15 @@ export const ApiKeyManagementTab = ({
 
   const handleDeleteConfirm = async () => {
     if (!deleteDialogState.request) return;
-    await handleDeleteRequest(deleteDialogState.request.metadata.namespace, deleteDialogState.request.metadata.name);
+    const apiKeyRef = deleteDialogState.request.spec?.apiKeyRef;
+    if (apiKeyRef) {
+      await handleDeleteRequest(apiKeyRef.namespace, apiKeyRef.name);
+    } else {
+      await handleDeleteRequest(
+        deleteDialogState.request.metadata.namespace,
+        deleteDialogState.request.metadata.name,
+      );
+    }
     setDeleteDialogState({ open: false, request: null });
   };
 

--- a/plugins/kuadrant/src/components/ApiProductInfoCard/ApiProductInfoCard.tsx
+++ b/plugins/kuadrant/src/components/ApiProductInfoCard/ApiProductInfoCard.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useApi, identityApiRef } from '@backstage/core-plugin-api';
-import { InfoCard, Progress, ResponseErrorPanel } from '@backstage/core-components';
+import { InfoCard, ResponseErrorPanel } from '@backstage/core-components';
 import { Typography, Box, makeStyles } from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
 import useAsync from 'react-use/lib/useAsync';
 import { useKuadrantPermission } from '../../utils/permissions';
 import { kuadrantApiProductReadAllPermission } from '../../permissions';
@@ -62,7 +63,13 @@ export const ApiProductInfoCard = () => {
   if (loading || permLoading) {
     return (
       <InfoCard title="API Product Information">
-        <Progress />
+        <Box p={2}>
+          {[...Array(5)].map((_, i) => (
+            <Box key={i} mb={2}>
+              <Skeleton variant="text" width="100%" />
+            </Box>
+          ))}
+        </Box>
       </InfoCard>
     );
   }

--- a/plugins/kuadrant/src/components/EditAPIProductDialog/EditAPIProductDialog.tsx
+++ b/plugins/kuadrant/src/components/EditAPIProductDialog/EditAPIProductDialog.tsx
@@ -25,9 +25,8 @@ import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import AddIcon from '@material-ui/icons/Add';
 import { useApi } from '@backstage/core-plugin-api';
 import { kuadrantApiRef } from '../../api';
-import { Alert } from '@material-ui/lab';
+import { Alert, Skeleton } from '@material-ui/lab';
 import useAsync from 'react-use/lib/useAsync';
-import { Progress } from '@backstage/core-components';
 import { ApiProductPolicies, PlanPoliciesProps, AuthPoliciesProps, RateLimitPoliciesProps } from '../ApiProductPolicies';
 import { validateURL } from '../../utils/validation';
 import { APIProduct } from "../../types/api-management.ts";
@@ -251,7 +250,13 @@ export const EditAPIProductDialog = ({ open, onClose, onSuccess, namespace, name
           </Alert>
         )}
         {loading ? (
-          <Progress />
+          <Box p={2}>
+            {[...Array(8)].map((_, i) => (
+              <Box key={i} mb={2}>
+                <Skeleton variant="text" width="100%" />
+              </Box>
+            ))}
+          </Box>
         ) : (
           <>
             {/* API product info section */}

--- a/plugins/kuadrant/src/components/KuadrantPage/ApiProductsPage.tsx
+++ b/plugins/kuadrant/src/components/KuadrantPage/ApiProductsPage.tsx
@@ -5,9 +5,9 @@ import {
   Chip,
   Button,
   IconButton,
-  CircularProgress,
   makeStyles,
 } from "@material-ui/core";
+import { Skeleton } from "@material-ui/lab";
 import AddIcon from "@material-ui/icons/Add";
 import DeleteIcon from "@material-ui/icons/Delete";
 import EditIcon from "@material-ui/icons/Edit";
@@ -749,20 +749,12 @@ const ResourceList = () => {
       </Header>
       <Content>
         {loading && (
-          <Box
-            display="flex"
-            flexDirection="column"
-            alignItems="center"
-            justifyContent="center"
-            minHeight={300}
-          >
-            <CircularProgress />
-            <Typography variant="h6" style={{ marginTop: 16 }}>
-              Loading data...
-            </Typography>
-            <Typography variant="body2" color="textSecondary">
-              Preparing your data... This should only take a moment.
-            </Typography>
+          <Box p={2}>
+            {[...Array(5)].map((_, i) => (
+              <Box key={i} p={2}>
+                <Skeleton variant="text" width="100%" />
+              </Box>
+            ))}
           </Box>
         )}
         {error && <ResponseErrorPanel error={error} />}

--- a/plugins/kuadrant/src/components/PermissionGate/PermissionGate.tsx
+++ b/plugins/kuadrant/src/components/PermissionGate/PermissionGate.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Typography, Box } from '@material-ui/core';
-import { Progress } from '@backstage/core-components';
+import { Skeleton } from '@material-ui/lab';
 import { Permission } from '@backstage/plugin-permission-common';
 import { useKuadrantPermission } from '../../utils/permissions';
 
@@ -15,7 +15,15 @@ export const PermissionGate = ({ children, permission, fallback, errorMessage }:
   const { allowed, loading, error } = useKuadrantPermission(permission);
 
   if (loading) {
-    return <Progress />;
+    return (
+      <Box p={2}>
+        {[...Array(5)].map((_, i) => (
+          <Box key={i} p={2}>
+            <Skeleton variant="text" width="100%" />
+          </Box>
+        ))}
+      </Box>
+    );
   }
 
   if (error) {

--- a/plugins/kuadrant/src/plugin.ts
+++ b/plugins/kuadrant/src/plugin.ts
@@ -45,7 +45,7 @@ export const ApiKeyApprovalPage = kuadrantPlugin.provide(
   createRoutableExtension({
     name: 'ApiKeyApprovalPage',
     component: () =>
-      import('./components/ApiKeyApprovalPage').then(m => m.ApiKeyApprovalPage),
+      import('./components/ApiKeyApprovalPage').then(m => m.ApiKeyApprovalPageWithPermissions),
     mountPoint: rootRouteRef,
   }),
 );

--- a/plugins/kuadrant/src/types/api-management.ts
+++ b/plugins/kuadrant/src/types/api-management.ts
@@ -36,6 +36,10 @@ export interface APIKeySpec {
     name: string;
     namespace: string;
   };
+  apiKeyRef?: {
+    name: string;
+    namespace: string;
+  };
   planTier: PlanTier;
   useCase: string;
   requestedBy: {

--- a/plugins/kuadrant/src/types/api-management.ts
+++ b/plugins/kuadrant/src/types/api-management.ts
@@ -36,10 +36,6 @@ export interface APIKeySpec {
     name: string;
     namespace: string;
   };
-  apiKeyRef?: {
-    name: string;
-    namespace: string;
-  };
   planTier: PlanTier;
   useCase: string;
   requestedBy: {


### PR DESCRIPTION
## Summary
- restrict `DELETE /requests/:namespace/:name` to consumer self-delete only — owners and admins can no longer delete API keys directly (access revocation happens via the approval resource)
- add unit tests for `GET /requests` and `GET /requests/my` list endpoints
- add e2e happy path test for consumer API key deletion
- fix pre-existing e2e lint errors (unused vars, deprecated networkidle, missing toHaveText arg)

closes #294

## Changes

### Backend (`plugins/kuadrant-backend/src/router.ts`)
the delete endpoint now only supports one path:
- **consumer** (`deleteOwn` + `requestedBy.userId` matches): delete their own APIKey

owner/admin deletion paths have been removed — access revocation should happen through the approval resource instead.

### Frontend (`plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx`)
simplified `handleDeleteConfirm` to always use `metadata.namespace`/`metadata.name` directly. removed `apiKeyRef` branching that was only needed for owner revocation.

## Verification

### Unit tests
```bash
cd plugins/kuadrant-backend && yarn test
```

**DELETE endpoint (3 tests):**
- consumer deletes own APIKey (204)
- consumer tries to delete another user's APIKey (403)
- user with no delete permissions (403)

**GET /requests — owner/admin view (5 tests)**
**GET /requests/my — consumer view (5 tests)**

### E2e tests
```bash
cd e2e-tests && yarn test kuadrant-happy-path
```
- step 9: consumer deletes their approved API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability for users to delete their API keys from the management interface.

* **Improvements**
  * Enhanced page loading synchronisation for better stability and reliability.
  * Updated loading indicators with improved visual skeleton loaders for clearer feedback during data fetching.

* **Permissions & Access**
  * Refined permission controls for API Key Approval page access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-backstage-plugin/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->