### PR TITLE
updated all UI labels from Rejected to Denied for consistency

### DIFF
--- a/plugins/kuadrant/src/api.ts
+++ b/plugins/kuadrant/src/api.ts
@@ -136,7 +136,7 @@ export interface KuadrantAPI {
    * @param namespace - Kubernetes namespace
    * @param name - API key request name
    * @param reviewedBy - Reviewed By User / System
-   * @returns Promise with the rejected API key
+   * @returns Promise with the denied API key
    */
   rejectRequest(namespace: string, name: string, reviewedBy: string): Promise<APIKey>;
 

--- a/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
@@ -647,10 +647,9 @@ export const ApiKeyManagementTab = ({
       render: (row: APIKey) => {
         const phase = getAPIKeyPhase(row.status?.conditions || []);
         const isPending = phase === "Pending";
-        const displayLabel = phase === "Denied" ? "Rejected" : phase;
         return (
           <Chip
-            label={displayLabel}
+            label={phase}
             size="small"
             icon={isPending ? <HourglassEmptyIcon /> : <CancelIcon />}
             color={isPending ? "default" : "secondary"}
@@ -855,7 +854,7 @@ export const ApiKeyManagementTab = ({
         {rejectedRequests.length > 0 && (
           <Grid item>
             <Table
-              title="Rejected Requests"
+              title="Denied Requests"
               options={{
                 paging: rejectedRequests.length > 5,
                 pageSize: 20,

--- a/plugins/kuadrant/src/components/ApprovalQueueTable/ApprovalQueueTable.tsx
+++ b/plugins/kuadrant/src/components/ApprovalQueueTable/ApprovalQueueTable.tsx
@@ -386,7 +386,7 @@ const BulkAlertDialog = ({
             <Box className={classes.statRow}>
               <CheckCircleIcon style={{ color: '#4caf50' }} />
               <Typography variant="body1">
-                <strong>{successResults.length}</strong> API key{successResults.length !== 1 ? 's' : ''} {isApprove ? 'approved' : 'rejected'} successfully
+                <strong>{successResults.length}</strong> API key{successResults.length !== 1 ? 's' : ''} {isApprove ? 'approved' : 'denied'} successfully
               </Typography>
             </Box>
           </Box>
@@ -536,7 +536,7 @@ export const ApprovalQueueTable = () => {
   const filterSections: FilterSection[] = useMemo(() => {
     if (!value?.allRequests) return [];
 
-    const statusCounts = { Approved: 0, Pending: 0, Rejected: 0 };
+    const statusCounts = { Approved: 0, Pending: 0, Denied: 0 };
     const apiProductCounts = new Map<string, number>();
     const tierCounts = new Map<string, number>();
 
@@ -566,9 +566,9 @@ export const ApprovalQueueTable = () => {
             count: statusCounts.Approved,
           },
           {
-            value: "Rejected",
-            label: "Rejected",
-            count: statusCounts.Rejected,
+            value: "Denied",
+            label: "Denied",
+            count: statusCounts.Denied,
           },
         ],
       },
@@ -660,7 +660,7 @@ export const ApprovalQueueTable = () => {
         ),
       );
       setRefresh((r) => r + 1);
-      const action = dialogState.action === "approve" ? "approved" : "rejected";
+      const action = dialogState.action === "approve" ? "approved" : "denied";
       alertApi.post({
         message: `API key ${action}`,
         severity: "success",
@@ -720,7 +720,7 @@ export const ApprovalQueueTable = () => {
       const failedItems = bulkResponse.filter((res: any) => !res.success);
       const totalSuccess = failedItems.length === 0;
 
-      const action = isApprove ? "approved" : "rejected";
+      const action = isApprove ? "approved" : "denied";
 
       setBulkDialogState({
         open: false,

--- a/plugins/kuadrant/src/components/MyApiKeysTable/MyApiKeysTable.tsx
+++ b/plugins/kuadrant/src/components/MyApiKeysTable/MyApiKeysTable.tsx
@@ -88,7 +88,7 @@ const ExpandedRowContent = ({ request }: ExpandedRowProps) => {
         <Box className={classes.rejectedBanner}>
           <WarningIcon color="error" fontSize="small" />
           <Typography variant="body2">
-            This API key was rejected.{" "}
+            This API key was denied.{" "}
             <Link to={`/catalog/default/api/${apiProductName}/api-keys`}>
               Request a new API key
             </Link>
@@ -167,13 +167,12 @@ export const MyApiKeysTable = () => {
     );
   }, [data?.requests, optimisticallyDeleted]);
 
-  // normalize phase to UI status (Denied → Rejected for display)
-  const toUiStatus = (phase: ReturnType<typeof getAPIKeyPhase>) =>
-    phase === 'Denied' ? 'Rejected' : phase;
+  // pass through phase as-is for UI display
+  const toUiStatus = (phase: ReturnType<typeof getAPIKeyPhase>) => phase;
 
   // filter options from data
   const filterSections: FilterSection[] = useMemo(() => {
-    const statusCounts = { Approved: 0, Pending: 0, Rejected: 0, Failed: 0 };
+    const statusCounts = { Approved: 0, Pending: 0, Denied: 0, Failed: 0 };
     const apiProductCounts = new Map<string, number>();
     const tierCounts = new Map<string, number>();
 
@@ -199,9 +198,9 @@ export const MyApiKeysTable = () => {
           { value: "Approved", label: "Active", count: statusCounts.Approved },
           { value: "Pending", label: "Pending", count: statusCounts.Pending },
           {
-            value: "Rejected",
-            label: "Rejected",
-            count: statusCounts.Rejected,
+            value: "Denied",
+            label: "Denied",
+            count: statusCounts.Denied,
           },
           { value: "Failed", label: "Failed", count: statusCounts.Failed },
         ],

--- a/plugins/kuadrant/src/types/api-management.ts
+++ b/plugins/kuadrant/src/types/api-management.ts
@@ -1,5 +1,5 @@
 export type PlanTier = string; // custom tier names defined by api owners
-export type RequestPhase = 'Pending' | 'Approved' | 'Rejected';
+export type RequestPhase = 'Pending' | 'Approved' | 'Denied';
 export type Lifecycle = 'experimental' | 'production' | 'deprecated' | 'retired';
 
 export interface PlanLimits {

--- a/plugins/kuadrant/src/utils/styles.ts
+++ b/plugins/kuadrant/src/utils/styles.ts
@@ -8,7 +8,6 @@ export const getMyApiKeysStatusChipStyle = (phase: string): CSSProperties => {
   switch (phase) {
     case "Approved":
       return { ...base, backgroundColor: "#1976d2", color: "#fff" }; // Blue
-    case "Rejected":
     case "Denied":
       return { ...base, backgroundColor: "#d32f2f", color: "#fff" }; // Red
     case "Failed":
@@ -29,7 +28,6 @@ export const getApprovalQueueStatusChipStyle = (phase: string): CSSProperties =>
   switch (phase) {
     case "Approved":
       return { ...base, backgroundColor: "#2e7d32", color: "#fff" }; // Green
-    case "Rejected":
     case "Denied":
       return { ...base, backgroundColor: "#d32f2f", color: "#fff" }; // Red
     case "Pending":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardised API key request terminology from "Rejected" to "Denied" across the interface.
  * Updated status labels, table headings, filter options, counts, banners and notification messages to use "Denied".
  * Status chip styling and displayed status texts now consistently reflect the "Denied" terminology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-backstage-plugin/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->