### PR TITLE
Fix: Make reject endpoint consistent with approve

### DIFF
--- a/plugins/kuadrant-backend/src/router.ts
+++ b/plugins/kuadrant-backend/src/router.ts
@@ -1211,7 +1211,7 @@ export async function createRouter({
         approval,
       );
 
-      res.status(204).send();
+      res.json({ success: true });
     } catch (error) {
       console.error('error rejecting api key request:', error);
       if (error instanceof NotAllowedError) {


### PR DESCRIPTION
## Fix: Make reject endpoint consistent with approve endpoint HTTP response

### Problem
The API key request approval and rejection endpoints were returning inconsistent response formats:
- **Approve endpoint**: Returns `200 OK` with JSON body `{ "success": true }`
- **Reject endpoint**: Returns `204 No Content` with empty body

This inconsistency could cause confusion for frontend clients expecting the same response format from both operations.

### Solution
Changed the reject endpoint (`POST /requests/{namespace}/{name}/reject`) to return the same response format as the approve endpoint:

**Before:**
```typescript
res.status(204).send();
```

**After:**
```typescript
res.json({ success: true });
```

### Changes Made
- **File**: `plugins/kuadrant-backend/src/router.ts`
- **Line**: 1214
- **Change**: Replace `res.status(204).send()` with `res.json({ success: true })`

### Benefits
- **API Consistency**: Both approve and reject endpoints now return the same response format
- **Client Simplicity**: Frontend code can handle both operations with the same response parsing logic
- **Better UX**: Consistent JSON responses make debugging and logging easier

### Testing
Both endpoints now return:
- **Status**: `200 OK`
- **Body**: `{ "success": true }`

This change aligns with the existing bulk approve/reject operations which already follow this pattern.

---

**Type**: Bug Fix  
**Component**: Backend API  
**Breaking Change**: No (response format change is backwards compatible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The request rejection API endpoint now returns explicit JSON confirmation rather than an empty response. This provides improved visibility into operation success, enables API consumers to better verify rejection status, and facilitates more robust client-side error handling and status validation throughout integrated systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-backstage-plugin/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->