### PR TITLE
doc/installation.md: adding missing permissions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -890,6 +890,9 @@ p, role:default/api-consumer, kuadrant.ratelimitpolicy.list, read, allow
 p, role:default/api-consumer, kuadrant.httproute.list, read, allow
 
 # api owner: publishes apis they own, approves requests for their apis
+p, role:default/api-owner, kuadrant.httproute.list, read, allow
+p, role:default/api-owner, kuadrant.ratelimitpolicy.list, read, allow
+p, role:default/api-owner, kuadrant.authpolicy.list, read, allow
 p, role:default/api-owner, kuadrant.planpolicy.read, read, allow
 p, role:default/api-owner, kuadrant.planpolicy.list, read, allow
 p, role:default/api-owner, kuadrant.apiproduct.create, create, allow


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RBAC policy examples in installation documentation with additional read permissions for the `api-owner` role, including list operations for HTTPRoute, RateLimitPolicy, and AuthPolicy resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->