### PR TITLE
🔨 support for custom plan limits

### DIFF
--- a/plugins/kuadrant/src/components/ApiProductDetails/ApiProductDetails.tsx
+++ b/plugins/kuadrant/src/components/ApiProductDetails/ApiProductDetails.tsx
@@ -14,6 +14,7 @@ import {
 import { Link } from "@backstage/core-components";
 import { APIProduct, Plan } from "../../types/api-management";
 import { getLifecycleChipStyle } from "../../utils/styles";
+import { getPlanLimitLines } from "../../utils/policies";
 
 const useStyles = makeStyles((theme) => ({
   label: {
@@ -229,12 +230,11 @@ export const ApiProductDetails = ({
                     <Chip label={plan.tier} size="small" />
                   </TableCell>
                   <TableCell>
-                    {plan.limits &&
-                      Object.entries(plan.limits).map(([key, value]) => (
-                        <Typography key={key} variant="body2">
-                          {String(value)} per {key}
-                        </Typography>
-                      ))}
+                    {getPlanLimitLines(plan.limits).map((line, idx) => (
+                      <Typography key={idx} variant="body2">
+                        {line}
+                      </Typography>
+                    ))}
                   </TableCell>
                 </TableRow>
               ))}

--- a/plugins/kuadrant/src/components/ApiProductPolicies/ApiProductPolicies.tsx
+++ b/plugins/kuadrant/src/components/ApiProductPolicies/ApiProductPolicies.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { Box, Grid, Typography, Chip, useTheme } from '@material-ui/core';
-import { StatusCondition } from "../../types/api-management";
+import { StatusCondition, PlanLimits } from "../../types/api-management";
+import { formatPlanLimits } from '../../utils/policies';
 
 export type PlanPoliciesProps = {
   statusCondition: StatusCondition | null;
   discoveredPlans: Array<{
     tier: string;
-    limits?: {
-      daily?: number;
-      monthly?: number;
-      yearly?: number;
-    };
+    limits?: PlanLimits;
   }> | null;
 };
 
@@ -82,13 +79,7 @@ export const ApiProductPolicies: React.FC<ApiProductPoliciesProps> = ({
                     </Typography>
                     <Box display="flex" flexWrap="wrap" mt={1} style={{ gap: 8 }}>
                       {planPolicy.discoveredPlans.map((plan: any, idx: number) => {
-                        const limitText = plan.limits?.daily
-                          ? `${plan.limits.daily}/day`
-                          : plan.limits?.monthly
-                            ? `${plan.limits.monthly}/month`
-                            : plan.limits?.yearly
-                              ? `${plan.limits.yearly}/year`
-                              : 'No limit';
+                        const limitText = formatPlanLimits(plan.limits) || 'No limit';
                         return (
                           <Chip
                             key={idx}

--- a/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
+++ b/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
@@ -17,6 +17,7 @@ import {
 import { useApi } from "@backstage/core-plugin-api";
 import { kuadrantApiRef } from '../../api';
 import { APIKey } from "../../types/api-management";
+import { formatPlanLimits } from '../../utils/policies';
 
 interface EditAPIKeyDialogProps {
   open: boolean;
@@ -117,9 +118,7 @@ export const EditAPIKeyDialog = ({
             disabled={saving}
           >
             {availablePlans.map((plan) => {
-              const limitDesc = Object.entries(plan.limits || {})
-                .map(([key, val]) => `${val} per ${key}`)
-                .join(", ");
+              const limitDesc = formatPlanLimits(plan.limits);
               return (
                 <MenuItem key={plan.tier} value={plan.tier}>
                   {plan.tier} {limitDesc ? `(${limitDesc})` : ""}

--- a/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
@@ -21,6 +21,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { kuadrantApiRef } from '../../api';
 import { Plan } from "../../types/api-management.ts";
+import { formatPlanLimits } from '../../utils/policies';
 
 export interface RequestAccessDialogProps {
   open: boolean;
@@ -166,9 +167,7 @@ export const RequestAccessDialog = ({
             disabled={creating}
           >
             {plans.map((plan: Plan) => {
-              const limitDesc = Object.entries(plan.limits || {})
-                .map(([key, val]) => `${val} per ${key}`)
-                .join(', ');
+              const limitDesc = formatPlanLimits(plan.limits);
               return (
                 <MenuItem
                   key={plan.tier}

--- a/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
@@ -23,6 +23,7 @@ import {
 } from '@backstage/core-plugin-api';
 import useAsync from 'react-use/lib/useAsync';
 import { kuadrantApiRef } from '../../api';
+import { formatPlanLimits } from '../../utils/policies';
 
 export interface SimpleRequestAccessDialogProps {
   open: boolean;
@@ -283,10 +284,8 @@ export const SimpleRequestAccessDialog = ({
             ) : availableTiers.length === 0 ? (
               <MenuItem disabled>No tiers available</MenuItem>
             ) : (
-              availableTiers.map((plan: { tier: string; limits?: Record<string, number> }) => {
-                const limitDesc = Object.entries(plan.limits || {})
-                  .map(([key, val]) => `${val} per ${key}`)
-                  .join(', ');
+              availableTiers.map((plan: { tier: string; limits?: any }) => {
+                const limitDesc = formatPlanLimits(plan.limits);
                 return (
                   <MenuItem key={plan.tier} value={plan.tier}>
                     {plan.tier} {limitDesc ? `(${limitDesc})` : ''}

--- a/plugins/kuadrant/src/utils/policies.test.ts
+++ b/plugins/kuadrant/src/utils/policies.test.ts
@@ -1,4 +1,72 @@
-import { getPolicyForRoute } from './policies';
+import { getPolicyForRoute, getPlanLimitLines, formatPlanLimits } from './policies';
+
+describe('getPlanLimitLines', () => {
+  it('returns empty array for undefined', () => {
+    expect(getPlanLimitLines(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for empty object', () => {
+    expect(getPlanLimitLines({})).toEqual([]);
+  });
+
+  it('handles daily limit', () => {
+    expect(getPlanLimitLines({ daily: 100 })).toEqual(['100 per day']);
+  });
+
+  it('handles weekly limit', () => {
+    expect(getPlanLimitLines({ weekly: 500 })).toEqual(['500 per week']);
+  });
+
+  it('handles monthly limit', () => {
+    expect(getPlanLimitLines({ monthly: 1000 })).toEqual(['1000 per month']);
+  });
+
+  it('handles yearly limit', () => {
+    expect(getPlanLimitLines({ yearly: 10000 })).toEqual(['10000 per year']);
+  });
+
+  it('handles custom limits array with one entry', () => {
+    expect(getPlanLimitLines({ custom: [{ limit: 50, window: '1m' }] })).toEqual(['50 per 1m']);
+  });
+
+  it('handles custom limits array with multiple entries', () => {
+    expect(getPlanLimitLines({ custom: [{ limit: 10, window: '10s' }, { limit: 100, window: '1h' }] }))
+      .toEqual(['10 per 10s', '100 per 1h']);
+  });
+
+  it('combines standard and custom limits in order', () => {
+    expect(getPlanLimitLines({ daily: 200, custom: [{ limit: 5, window: '1s' }] }))
+      .toEqual(['200 per day', '5 per 1s']);
+  });
+
+  it('emits one line per standard field present', () => {
+    expect(getPlanLimitLines({ daily: 10, monthly: 100, yearly: 1000 }))
+      .toEqual(['10 per day', '100 per month', '1000 per year']);
+  });
+});
+
+describe('formatPlanLimits', () => {
+  it('returns empty string for undefined', () => {
+    expect(formatPlanLimits(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty object', () => {
+    expect(formatPlanLimits({})).toBe('');
+  });
+
+  it('joins multiple limits with comma', () => {
+    expect(formatPlanLimits({ daily: 100, monthly: 1000 })).toBe('100 per day, 1000 per month');
+  });
+
+  it('formats custom limits correctly', () => {
+    expect(formatPlanLimits({ custom: [{ limit: 50, window: '1m' }] })).toBe('50 per 1m');
+  });
+
+  it('formats mixed standard and custom limits', () => {
+    expect(formatPlanLimits({ daily: 200, custom: [{ limit: 5, window: '1s' }] }))
+      .toBe('200 per day, 5 per 1s');
+  });
+});
 
 describe('getPolicyForRoute', () => {
   describe('null and undefined policies', () => {

--- a/plugins/kuadrant/src/utils/policies.ts
+++ b/plugins/kuadrant/src/utils/policies.ts
@@ -1,3 +1,29 @@
+import { PlanLimits } from '../types/api-management';
+
+/**
+ * Return PlanLimits as an array of human-readable strings.
+ * Handles standard period fields (daily/weekly/monthly/yearly) and
+ * custom limits (array of { limit, window }).
+ */
+export const getPlanLimitLines = (limits: PlanLimits | undefined): string[] => {
+  if (!limits) return [];
+  const parts: string[] = [];
+  if (limits.daily) parts.push(`${limits.daily} per day`);
+  if (limits.weekly) parts.push(`${limits.weekly} per week`);
+  if (limits.monthly) parts.push(`${limits.monthly} per month`);
+  if (limits.yearly) parts.push(`${limits.yearly} per year`);
+  if (limits.custom) {
+    for (const item of limits.custom) {
+      parts.push(`${item.limit} per ${item.window}`);
+    }
+  }
+  return parts;
+};
+
+/** Convenience wrapper that joins limit lines with a comma for single-line display. */
+export const formatPlanLimits = (limits: PlanLimits | undefined): string =>
+  getPlanLimitLines(limits).join(', ');
+
 /**
  * Find a policy that targets a specific APIProduct
  *


### PR DESCRIPTION
### WHAT

The frontend could not render plan tiers whose limits used custom time windows (e.g. `10s`, `1h`). The `PlanLimits` type only exposed `daily`, `weekly`, `monthly`, and `yearly` fields, so any `custom` limits from the PlanPolicy CRD were silently dropped.

This PR:
- Adds a `custom` field to `PlanLimits` — an array of `{ limit, window }` entries that maps directly to the CRD's `spec.plans[].limits.custom`
- Extracts `formatPlanLimits` (single-line summary) and `getPlanLimitLines` (one line per limit) helpers so all components (request-access dialog, edit-key dialog, API product details table, and policies tab) render limits consistently
- Replaces the ad-hoc `Object.entries(plan.limits)` patterns in each component with these shared helpers

### Verification steps

* Run dev environment
```shell
# Create kind cluster with Kuadrant
make -C kuadrant-dev-setup  kind-create

# Start development server with hot reload
yarn dev
```

* Patch `gamestore-admin-tiers` plan policy to have custom limits
```bash
kubectl patch planpolicy gamestore-admin-tiers -n gamestore --type=json \
  -p='[{"op":"add","path":"/spec/plans/-","value":{"tier":"burst","predicate":"has(auth.identity) && auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"burst\"","limits":{"custom":[{"limit":10,"window":"10s"},{"limit":500,"window":"1h"}]}}}]'
```

* Access the UI as consumer (localhost:3000), select `gamestore-admin` apiproduct and check the tiers are correctly being displayed
<img width="623" height="452" alt="Screenshot from 2026-06-12 13-47-23" src="https://github.com/user-attachments/assets/0b2eb3f0-0655-425a-af92-88f69eb92889" />

* Clean up

```shell
make -C kuadrant-dev-setup  kind-delete
```
