### PR TITLE
fix: create release tag on triggering branch instead of main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           name: Release ${{ steps.version.outputs.tag }}
           body_path: CHANGELOG.md
           draft: false


### PR DESCRIPTION
## Description
Added `target_commitish: ${{ github.sha }}` so the tag is created on the exact commit the workflow ran against.

Closes #328 

## Verification
Tested on a fork by triggering the Release workflow from a `release-test` branch. The tag was correctly created on that 
branch's commit (`ee04083`) not on `main`.

- Workflow run: https://github.com/Priyanshu-u07/kuadrant-backstage-plugin/actions/runs/27878059917
- Release created: https://github.com/Priyanshu-u07/kuadrant-backstage-plugin/releases/tag/v0.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration for improved release handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->