### PR TITLE
chore: add contributor governance workflow

### DIFF
--- a/.github/workflows/contributor-governance.yml
+++ b/.github/workflows/contributor-governance.yml
@@ -1,0 +1,12 @@
+name: Contributor Governance
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  governance:
+    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@main
+    secrets: inherit


### PR DESCRIPTION
adds the thin caller workflow for the centralized contributor governance automation from Kuadrant/.github#3.

this enables:
- auto-labeling new issues with `triage/needs-triage`
- protecting triage labels from non-org-members
- closing PRs that don't link to a triaged issue
- preventing duplicate external PRs for the same issue

the `triage/*` labels already exist in this repo, so this is all that's needed to activate the automation.