### PR TITLE
chore: sync contributor-governance workflow from .github

### DIFF
--- a/.github/workflows/contributor-governance.yml
+++ b/.github/workflows/contributor-governance.yml
@@ -1,12 +1,433 @@
+# Centralized contributor governance workflow for the Kuadrant org.
+# Called by thin caller workflows in each target repo.
+#
+# Jobs:
+#   1. label-new-issues     — auto-labels new issues with triage/needs-triage
+#   2. protect-triage-labels — reverts triage label changes by non-org-members
+#   3. check-pr              — closes PRs without a linked, triaged, assigned issue
+#
+# Org members (Kuadrant) are exempt from all enforcement.
+# Requires org-level secret ORG_MEMBER_TOKEN with read:org scope.
+#
 name: Contributor Governance
 
 on:
-  issues:
-    types: [opened, labeled, unlabeled]
-  pull_request_target:
-    types: [opened, reopened]
+  workflow_call:
+    secrets:
+      ORG_MEMBER_TOKEN:
+        required: true
+        description: PAT with read:org scope for org membership checks
 
 jobs:
-  governance:
-    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@main
-    secrets: inherit
+  # ──────────────────────────────────────────────────────────────
+  # Job 1: Auto-label new issues with triage/needs-triage
+  # ──────────────────────────────────────────────────────────────
+  label-new-issues:
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add triage label to new issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['triage/needs-triage']
+            });
+
+  # ──────────────────────────────────────────────────────────────
+  # Job 2: Protect triage labels from non-org-members
+  #
+  # If a non-org-member adds or removes a triage/* label,
+  # revert the change and ensure triage/needs-triage is present.
+  # ──────────────────────────────────────────────────────────────
+  protect-triage-labels:
+    if: github.event_name == 'issues' && (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Protect triage labels from non-org-members
+        uses: actions/github-script@v7
+        env:
+          ORG_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
+        with:
+          script: |
+            const label = context.payload.label.name;
+
+            // Ignore non-triage labels entirely
+            if (!label.startsWith('triage/')) {
+              console.log(`Label ${label} is not a triage label, skipping`);
+              return;
+            }
+
+            const actor = context.actor;
+            const org = context.repo.owner;
+
+            // Org members can change labels freely — check membership via org token
+            // NOTE: TEST_MODE is intentionally NOT applied here so maintainers
+            // can still manage labels during testing.
+            // Uses fetch instead of github.request because Octokit overrides
+            // custom auth headers with its own GITHUB_TOKEN.
+            const labelRes = await fetch(
+              `https://api.github.com/orgs/${org}/members/${actor}`,
+              { headers: { authorization: `token ${process.env.ORG_TOKEN}` } }
+            );
+
+            if (labelRes.status === 204) {
+              console.log(`${actor} is an org member, allowing triage label change`);
+              return;
+            }
+
+            if (labelRes.status !== 404) {
+              throw new Error(`Org membership check failed with status ${labelRes.status}`);
+            }
+
+            // --- Non-org-member tried to modify a triage label ---
+
+            // If they added a label, remove it first
+            if (context.payload.action === 'labeled') {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: label
+              });
+            }
+
+            // Re-fetch to see what triage labels remain
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const hasTriageLabel = issue.data.labels.some(l => l.name.startsWith('triage/'));
+
+            // An issue should never have zero triage labels
+            if (!hasTriageLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['triage/needs-triage']
+              });
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'Hey! Triage labels are managed by the Kuadrant maintainers. The label has been reverted. If you think this issue should be re-prioritised, leave a comment and a maintainer will take a look.'
+            });
+
+  # ──────────────────────────────────────────────────────────────
+  # Job 3: Validate PRs have a linked, triaged issue
+  #
+  # Sequential checks (stops at first failure):
+  #   a) PR must reference at least one issue (via GitHub link or #N in body)
+  #   b) At least one linked issue must be open
+  #   c) At least one open linked issue must have triage/accepted
+  #   d) No linked accepted issue has the maintainers-only label
+  #   e) No other non-org-member PR already targets the same issue
+  #   f) PR author must be assigned to the linked issue
+  # ──────────────────────────────────────────────────────────────
+  check-pr:
+    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (github.event.action == 'opened' || github.event.action == 'reopened')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: read
+    steps:
+      - name: Check PR requirements
+        uses: actions/github-script@v7
+        env:
+          ORG_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
+        with:
+          script: |
+            const actor = context.payload.pull_request.user.login;
+            const org = context.repo.owner;
+
+            // --- Org membership check: org members skip all PR rules ---
+            const res = await fetch(
+              `https://api.github.com/orgs/${org}/members/${actor}`,
+              { headers: { authorization: `token ${process.env.ORG_TOKEN}` } }
+            );
+            if (res.status === 204) {
+              console.log(`${actor} is an org member, skipping PR checks`);
+              return;
+            }
+            if (res.status !== 404) throw new Error(`Org membership check failed: ${res.status}`);
+
+            // ── Rule 2: Find linked issues ──
+            // Two methods: GraphQL closingIssuesReferences + regex scan of PR text
+
+            const prNumber = context.payload.pull_request.number;
+            const prTitle = context.payload.pull_request.title;
+            const prBody = context.payload.pull_request.body || '';
+
+            // Method 1: GraphQL — gets formally linked issues
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 100) {
+                      nodes {
+                        number
+                        state
+                        labels(first: 100) {
+                          nodes {
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const graphqlResult = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: prNumber
+            });
+
+            const closingIssues = graphqlResult.repository.pullRequest.closingIssuesReferences.nodes || [];
+            const linkedIssues = new Map();
+
+            for (const issue of closingIssues) {
+              linkedIssues.set(issue.number, {
+                number: issue.number,
+                state: issue.state,
+                labels: issue.labels.nodes.map(l => l.name)
+              });
+            }
+
+            // Method 2: Regex — catches #N references, Kuadrant/repo#N, and full GitHub URLs
+            const patterns = [
+              /(?:(?:closes?|fixe?s?|resolves?)\s+)?(?:Kuadrant\/[\w-]+)?#(\d+)/gi,
+              /https?:\/\/github\.com\/Kuadrant\/[\w-]+\/issues\/(\d+)/gi
+            ];
+            const text = `${prTitle}\n${prBody}`;
+            let match;
+
+            for (const issueRegex of patterns) {
+            while ((match = issueRegex.exec(text)) !== null) {
+              const issueNumber = parseInt(match[1]);
+              if (!linkedIssues.has(issueNumber)) {
+                try {
+                  const issue = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber
+                  });
+
+                  // GitHub's issues API returns PRs too — skip those
+                  if (!issue.data.pull_request) {
+                    linkedIssues.set(issueNumber, {
+                      number: issueNumber,
+                      state: issue.data.state,
+                      labels: issue.data.labels.map(l => l.name)
+                    });
+                  }
+                } catch (error) {
+                  console.log(`Could not fetch issue #${issueNumber}: ${error.message}`);
+                }
+              }
+            }
+            }
+
+            // Check A: PR must have at least one linked issue
+            if (linkedIssues.size === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: "Thanks for the contribution! PRs need to be linked to a triaged issue. If you've spotted something you'd like to work on, open an issue first and a maintainer will review it. Once it has `triage/accepted`, feel free to reopen this PR and link it."
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                state: 'closed'
+              });
+
+              return;
+            }
+
+            // ── Rule 3: Check issue is triaged ──
+
+            // Check B: At least one linked issue must be open
+            const openIssues = Array.from(linkedIssues.values()).filter(i => i.state === 'OPEN' || i.state === 'open');
+
+            if (openIssues.length === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: "Thanks for the contribution! The linked issue(s) are closed. Please link an open, triaged issue and reopen this PR."
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                state: 'closed'
+              });
+
+              return;
+            }
+
+            // Check C: At least one open issue must have triage/accepted
+            const acceptedIssues = openIssues.filter(i => i.labels.includes('triage/accepted'));
+
+            if (acceptedIssues.length === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: "Thanks for the contribution! The linked issue hasn't been triaged yet (needs `triage/accepted`). Once a maintainer has reviewed and accepted the issue, feel free to reopen this PR."
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                state: 'closed'
+              });
+
+              return;
+            }
+
+            // ── Check D: Maintainers-only issues are reserved for org members ──
+
+            const maintainersOnlyIssue = acceptedIssues.find(i => i.labels.includes('maintainers-only'));
+            if (maintainersOnlyIssue) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `Thanks for the contribution! The linked issue (#${maintainersOnlyIssue.number}) is marked as \`maintainers-only\` and is reserved for the maintainer team.`
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                state: 'closed'
+              });
+
+              return;
+            }
+
+            // ── Check E: No other non-org-member PR already targets the same issue ──
+
+            for (const issue of acceptedIssues) {
+              const prsInRepo = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100
+              });
+
+              for (const otherPr of prsInRepo.data) {
+                if (otherPr.number === prNumber) continue;
+                if (otherPr.user.login === actor) continue;
+
+                // Skip if the other PR author is an org member
+                const otherRes = await fetch(
+                  `https://api.github.com/orgs/${org}/members/${otherPr.user.login}`,
+                  { headers: { authorization: `token ${process.env.ORG_TOKEN}` } }
+                );
+                if (otherRes.status === 204) continue;
+                if (otherRes.status !== 404) throw new Error(`Org membership check failed for ${otherPr.user.login}: ${otherRes.status}`);
+
+                // Check if the other PR references the same issue
+                const otherPrQuery = `
+                  query($owner: String!, $repo: String!, $number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        closingIssuesReferences(first: 100) {
+                          nodes {
+                            number
+                          }
+                        }
+                      }
+                    }
+                  }
+                `;
+
+                const otherPrResult = await github.graphql(otherPrQuery, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  number: otherPr.number
+                });
+
+                const otherPrIssues = otherPrResult.repository.pullRequest.closingIssuesReferences.nodes || [];
+                const otherPrIssueNumbers = otherPrIssues.map(i => i.number);
+
+                if (otherPrIssueNumbers.includes(issue.number)) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: `Thanks for the contribution! The linked issue already has an open PR (#${otherPr.number}) from another contributor. If you think this is a different approach worth considering, leave a comment and a maintainer can reopen this.`
+                  });
+
+                  await github.rest.pulls.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: prNumber,
+                    state: 'closed'
+                  });
+
+                  return;
+                }
+              }
+            }
+
+            // ── Check F: PR author must be assigned to the linked issue ──
+
+            let assignedToAny = false;
+            const unassignedIssueNumbers = [];
+
+            for (const issue of acceptedIssues) {
+              const issueDetail = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number
+              });
+
+              const assignees = issueDetail.data.assignees.map(a => a.login);
+              if (assignees.includes(actor)) {
+                assignedToAny = true;
+                break;
+              }
+              unassignedIssueNumbers.push(issue.number);
+            }
+
+            if (!assignedToAny) {
+              const issueRefs = unassignedIssueNumbers.map(n => `#${n}`).join(', ');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `Thanks for the contribution! The linked issue (${issueRefs}) isn't assigned to you. Please request assignment on the issue first, and if assigned, feel free to reopen this PR.`
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                state: 'closed'
+              });
+
+              return;
+            }
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,182 +1,26 @@
-# Contributing
+# Contributing to Kuadrant
 
-We are excited to see you want to be a part of this project by contributing. Here is some information on how to get started, as well as some knowledge on our requirements.
+For general contribution guidance, see the [Kuadrant contributing guide](https://kuadrant.io/contributing/). This document covers the automated governance rules that apply across Kuadrant repositories.
 
-## Get Started
+## Issue Triage
 
-### Clone and Install
+All new issues are automatically labelled with `triage/needs-triage`. Once the team has discussed and prioritised an issue, a maintainer will move it to `triage/accepted`.
 
-```bash
-git clone https://github.com/your-username/rhdh.git   # Clone your forked repository
-cd rhdh                                               # Change to the project directory
-yarn install                                          # Install dependencies
-yarn tsc                                              # Run type generation and checks
-```
+| Label | Meaning |
+|---|---|
+| `triage/needs-triage` | New issue, awaiting maintainer review |
+| `triage/accepted` | Reviewed, prioritised, and ready for work |
 
-### Run the Showcase App
+Only maintainers can change triage labels.
 
-We currently have quite a bit of moving parts for the showcase application. As such, we have documentation dedicated to the requirements for running the showcase app under [getting-started.md](https://github.com/redhat-developer/rhdh/blob/main/docs/index.md).
+## Pull Request Requirements
 
-### Useful Scripts
+Every PR from an external contributor must:
 
-Our project uses [Turborepo](https://turbo.build/repo) for running scripts across packages efficiently. Here are some useful scripts used in the project:
+1. **Link to an issue** — use `Fixes #123` or `Closes #123` in the PR description, or link it via the GitHub sidebar.
+2. **Link to a triaged issue** — the linked issue must have the `triage/accepted` label.
+3. **Not target a maintainers-only issue** — issues labelled `maintainers-only` are reserved for the maintainer team.
+4. **Not duplicate existing work** — the linked issue must not already have an open PR from another contributor.
+5. **Be assigned to you** — you must be assigned to the linked issue before opening a PR. Leave a comment on the issue to request assignment.
 
-```bash
-yarn start             # Starts the backend application
-yarn dev               # Starts both backend and frontend applications
-yarn build             # Builds all packages
-yarn tsc               # Runs TypeScript type checks across all packages
-yarn test              # Runs tests across all packages
-yarn lint:check        # Checks for linting errors across all packages
-yarn lint:fix          # Fixes linting errors automatically across all packages
-yarn prettier:check    # Checks for formatting issues across all packages
-yarn prettier:fix      # Fixes formatting issues automatically across all packages
-yarn clean             # Cleans up build artifacts across all packages
-```
-
-## Contributions
-
-We welcome code and non-code contributions to our project. Non-code contributions can come in the form of documentation updates, bug reports, enhancement requests, and feature requests.
-
-### Finding Issues to Work On
-
-Want to submit some changes to the code? The best place to start is to look through our issues for [bugs](https://github.com/redhat-developer/rhdh/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug), [good first issues](https://github.com/redhat-developer/rhdh/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22), and [help wanted](https://github.com/redhat-developer/rhdh/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22). These are a great starting point for new contributors.
-
-### Bug Reporting
-
-If you found a bug in our showcase app, please submit an [issue](https://github.com/redhat-developer/rhdh/issues/new?assignees=&labels=kind%2Fbug%2Cstatus%2Ftriage&template=bug.md) describing the problem that you ran into. Important information to include:
-
-- Steps to reproduce the bug
-- The `app-config.yaml` that is being used (**remember to remove all secrets before sharing**)
-- Any relevant logs
-
-This will help us narrow down the potential cause of the bug and speed up the time it takes to solve the problem at hand.
-
-### Updating Backstage Dependencies
-
-To update Backstage dependencies, run the following command:
-
-```bash
-yarn versions:bump     # Updates Backstage dependencies
-```
-
-### Enhancement Requests
-
-If you want an enhancement of a feature or workflow, you can submit an [issue](https://github.com/redhat-developer/rhdh/issues/new?assignees=&labels=kind%2Fenhancement%2Cstatus%2Ftriage&template=enhancement.md) describing the enhancement. Include:
-
-- What you are wanting to see improved
-- The current behavior
-- The new behavior you wish to see
-
-### Feature Requests
-
-If you want to see a new feature within the showcase app, file an [issue](https://github.com/redhat-developer/rhdh/issues/new?assignees=&labels=kind%2Ffeature%2Cstatus%2Ftriage&template=feature.md) detailing the new feature. Include:
-
-- What you are trying to achieve with the new feature
-- What you will need
-- Who will have access
-- Any relevant documentation or information on the new feature
-
-### Documentation
-
-Documentation is another option for contributing to us. If there is documentation that is unclear or could use some improvements, please raise an issue or submit a pull request.
-
-### Pull Requests
-
-If you want to submit code changes to the project, here are some guidelines:
-
-1. **Create a Branch**
-
-   ```bash
-   git checkout -b your-feature-branch  # Create a new branch for your feature
-   ```
-
-2. **Implement Your Changes**
-
-   Make your code changes, ensuring that you follow the project's coding standards and best practices.
-
-3. **Testing**
-
-   - **Run Tests:** Ensure all tests pass before committing.
-
-     ```bash
-     yarn test         # Run unit tests
-     cd e2e-tests
-     yarn showcase     # Run e2e tests
-     ```
-
-     _For more on the e2e, check the [e2e contributing guidelines](./docs/e2e-tests/CONTRIBUTING.MD)_
-
-   - **Note on Environment Dependencies:**
-
-     - If your new or edited code can't be validated locally due to environment dependencies, you can open a **draft Pull Request (PR)**. This allows the tests to run on the test environment as described in our CI documentation.
-
-4. **Linting and Formatting**
-
-   Ensure your code passes linting and formatting checks.
-
-   ```bash
-   yarn lint:check     # Checks for linting errors
-   yarn lint:fix       # Fixes linting errors automatically
-   yarn prettier:check # Checks for formatting issues
-   yarn prettier:fix   # Fixes formatting issues automatically
-   ```
-
-5. **Ensure CI Passes**
-
-   Your contributions will need to pass the Continuous Integration (CI) tests for pull requests.
-
-6. **Commit Changes**
-
-   Use meaningful commit messages following the [Conventional Commits](https://www.conventionalcommits.org/) specification.
-
-   ```bash
-   git commit -m "feat: add new feature"  # Commit your changes with a meaningful message
-   ```
-
-7. **Update Documentation**
-
-   If there will be changes to the [app config](app-config.yaml), we ask that [documentation](README.md#getting-started) be updated if it will be a requirement for running the app. We also ask to ensure that the app will still work in the case of dummy information being supplied to the app config. While it is not a hard requirement, it does help others with quickly being able to get up and running with the showcase app.
-
-8. **Push to Your Fork**
-
-   ```bash
-   git push origin your-feature-branch    # Push your branch to your fork
-   ```
-
-9. **Open a Pull Request**
-
-   Go to the original repository and click on **New Pull Request**. Provide a clear description of your changes, including any issues your PR fixes, acceptance criteria, and any special notes to the reviewers.
-
-## Commit Messages
-
-Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
-
-- `feat`: A new feature.
-- `fix`: A bug fix.
-- `docs`: Documentation changes.
-- `style`: Code style changes (formatting, missing semi-colons, etc.).
-- `refactor`: Code changes that neither fix a bug nor add a feature.
-- `test`: Adding or correcting tests.
-- `chore`: Changes to the build process or auxiliary tools.
-
-### Adding Statically Linked Plugins for Frontend and Backend
-
-When contributing a new `@internal` plugin into this repo, you must remember to add the plugin to the Dockerfiles under the section titled `Stage 2 - Install dependencies`:
-
-- [Upstream Dockerfile](.rhdh/docker/Dockerfile)
-- [Downstream Dockerfile](docker/Dockerfile)
-
-For example:
-
-```dockerfile
-COPY $EXTERNAL_SOURCE_NESTED/plugins/dynamic-plugins-info/package.json ./plugins/dynamic-plugins-info/package.json
-```
-
-## Support
-
-You can reach out to us in our [community Slack channel](https://join.slack.com/t/janus-idp/shared_invite/zt-1pxtehxom-fCFtF9rRe3vFqUiFFeAkmg) if you run into any issues with setup, running, or testing the application. Members of the team and community can assist you with questions and concerns you might have. Even if you don't need help, please consider joining and being involved in our community.
-
-## License
-
-By contributing, you agree that your contributions will be licensed under the [Apache-2.0 License](https://github.com/redhat-developer/rhdh/blob/main/LICENSE).
+PRs that don't meet these requirements will be automatically closed. Your branch won't be deleted, so you can reopen once the requirements are met.


### PR DESCRIPTION
## Summary
- syncs contributor-governance.yml and CONTRIBUTING.md with Kuadrant/.github#5
- adds Check D (maintainers-only issues reserved for maintainers)
- adds Check F (PR author must be assigned to the linked issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated contributor governance checks for issues and pull requests.
  * New issue triage handling applies labels automatically and keeps triage labels consistent.
  * Pull requests are now checked for linked, accepted issues and other contribution requirements.

* **Bug Fixes**
  * Pull requests that do not meet the required contribution rules may be closed automatically.
  * Prevents conflicting or duplicate pull requests from moving forward.

* **Documentation**
  * Updated contribution guidance to reflect the new triage and pull request process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->