### PR TITLE
ci: run dynamic-plugin e2e against RHDH on oinc

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@
 plugins
 !plugins/auth-backend-module-oidc-provider
 !plugins/dynamic-plugins-info-backend
+!plugins/kuadrant
+!plugins/kuadrant-backend
 !plugins/licensed-users-info-backend
 !plugins/scalprum-backend
 *.local.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Setup RBAC and Kuadrant on kind cluster
         run: |
           cd kuadrant-dev-setup
-          kubectl apply -f rbac/rhdh-rbac.yaml
+          kubectl apply -f rbac/rhdh-cluster-role.yaml -f rbac/rhdh-rbac.yaml
           ./scripts/kube-env-setup.sh
           make kuadrant-install CLUSTER_NAME=kuadrant-test
           make demo-install

--- a/.github/workflows/e2e-dynamic.yml
+++ b/.github/workflows/e2e-dynamic.yml
@@ -1,0 +1,99 @@
+name: E2E (dynamic plugins)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  OINC_VERSION: v0.3.1
+  OCP_VERSION: "4.21"
+  KUADRANT_VERSION: "1.5.1"
+  RHDH_BASE_IMAGE: quay.io/rhdh-community/rhdh:1.10
+  RHDH_IMAGE_REPOSITORY: localhost/kuadrant-rhdh-e2e
+  RHDH_IMAGE_TAG: ci
+  RHDH_CHART_VERSION: "6.2.2"
+  RHDH_URL: http://rhdh.localhost:9080
+  DEX_URL: http://dex.localhost:9080
+
+jobs:
+  e2e-rhdh-dynamic:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost || true
+          df -h /
+
+      - name: Configure local routes
+        run: |
+          echo "127.0.0.1 rhdh.localhost" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 dex.localhost" | sudo tee -a /etc/hosts
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install oinc
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/oinc" \
+            "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
+          chmod +x "$RUNNER_TEMP/oinc"
+          sudo mv "$RUNNER_TEMP/oinc" /usr/local/bin/oinc
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install e2e dependencies
+        run: make e2e-deps PLAYWRIGHT_INSTALL_ARGS=--with-deps
+
+      - name: Build and start dynamic RHDH
+        run: make dynamic-up
+
+      - name: Run e2e tests
+        run: make e2e-specs
+
+      - name: RHDH diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n rhdh get pods,route,svc || true
+          kubectl -n rhdh logs -l app.kubernetes.io/component=backstage --all-containers --tail=300 || true
+          kubectl -n kuadrant-system get pods -o wide || true
+          kubectl -n localhost get pods || true
+          kubectl -n localhost logs deployment/dex --tail=100 || true
+          curl -fsS "$DEX_URL/.well-known/openid-configuration" || true
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-dynamic
+          path: e2e-tests/playwright-report/
+          retention-days: 7
+
+      - name: Upload test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts-dynamic
+          path: e2e-tests/test-results/
+          retention-days: 7
+
+      - name: Teardown oinc cluster
+        if: always()
+        run: make teardown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,27 @@ yarn test                       # run kuadrant e2e tests
 yarn test:smoke                 # run smoke tests only
 ```
 
-Tests available:
-- `kuadrant-plugin.spec.ts` - basic navigation and rendering tests
-- `kuadrant-rbac.spec.ts` - comprehensive RBAC permission tests covering all personas
+**Dynamic-plugin E2E (manually dispatched in CI):**
+```bash
+make e2e-dynamic                # build, bake, boot oinc, run the specs, tear down
+make preflight                  # check required tooling, change nothing
+```
+Needs oinc (pinned version), docker, helm, kubectl, curl, python3 and node/yarn, and
+installs none of them; it does run `yarn install` and `playwright install chromium`, as
+CI does. Cluster is left up on failure for inspection.
+
+For manual testing, run the same phases without the one-shot teardown:
+```bash
+make dynamic-up                 # build and leave the RHDH environment running
+make e2e-deps                   # install Playwright locally (once)
+make e2e-specs                  # run the specs against it (repeatable, no rebuild)
+make teardown                   # delete the cluster (no-op if there is none)
+```
+`dynamic-up` leaves RHDH at `http://rhdh.localhost:9080` and always rebuilds the image.
+It signs in through dex with the same five personas as `yarn dev`, so the whole spec set
+runs there. It deliberately skips Playwright installation for browser-only manual
+testing. After `e2e-deps`, `e2e-specs` forwards `PLAYWRIGHT_ARGS` and needs no rebuild.
+See [docs/e2e-testing.md](docs/e2e-testing.md) and [docs/oinc.md](docs/oinc.md).
 
 ### Linting and Formatting
 ```bash
@@ -138,12 +156,16 @@ yarn export-dynamic -- -- --dev # export all dynamic plugins for local dev
 ```
 
 ### Testing Different Roles
-```bash
-yarn user:consumer              # switch to API Consumer
-yarn user:owner                 # switch to API Owner
-yarn user:default               # restore default permissions
-```
-After switching roles, restart with `yarn dev`.
+
+`yarn dev` starts a local dex container on `:5556`; `make dynamic-up` deploys dex on the
+oinc cluster from the same files. Either way, sign in through the dex quick-login picker
+as one of five personas: `admin@kuadrant.local`, `owner1@`, `owner2@`, `consumer1@`,
+`consumer2@` (passwords match usernames). Sign out and back in to switch.
+
+Personas live in [`kuadrant-dev-setup/dex/config.yaml`](kuadrant-dev-setup/dex/config.yaml)
+and [`catalog-entities/kuadrant-users.yaml`](catalog-entities/kuadrant-users.yaml); their
+group membership maps to roles in [`rbac-policy.csv`](rbac-policy.csv). Adding a persona
+is a one-file edit that both environments pick up.
 
 ## Testing Infrastructure
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+.PHONY: help preflight dynamic-build e2e-deps dynamic-cluster dynamic-up \
+	e2e-specs e2e-dynamic teardown
+
+MAKEFLAGS += --no-print-directory
+
+OINC_VERSION ?= v0.3.1
+OCP_VERSION ?= 4.21
+KUADRANT_VERSION ?= 1.5.1
+RHDH_BASE_IMAGE ?= quay.io/rhdh-community/rhdh:1.10
+RHDH_IMAGE_REPOSITORY ?= localhost/kuadrant-rhdh-e2e
+RHDH_IMAGE_TAG ?= ci
+RHDH_CHART_VERSION ?= 6.2.2
+RHDH_URL ?= http://rhdh.localhost:9080
+DEX_URL ?= http://dex.localhost:9080
+PLAYWRIGHT_INSTALL_ARGS ?=
+PLAYWRIGHT_ARGS ?=
+
+RHDH_IMAGE = $(RHDH_IMAGE_REPOSITORY):$(RHDH_IMAGE_TAG)
+
+export OCP_VERSION KUADRANT_VERSION RHDH_BASE_IMAGE RHDH_IMAGE_REPOSITORY
+export RHDH_IMAGE_TAG RHDH_CHART_VERSION RHDH_URL DEX_URL
+
+help:
+	@echo "Dynamic-plugin RHDH testing:"
+	@echo "  make dynamic-up   build and start RHDH for manual testing"
+	@echo "  make e2e-deps     install the Playwright test dependencies"
+	@echo "  make e2e-specs    run the full e2e suite against a running RHDH"
+	@echo "  make e2e-dynamic  run the full build, test and teardown path"
+	@echo "  make teardown     delete the oinc cluster"
+	@echo ""
+	@echo "Override versions and image settings on the make command line."
+
+preflight:
+	@for tool in node yarn helm docker kubectl curl python3 oinc; do \
+		command -v $$tool >/dev/null 2>&1 || { echo "error: '$$tool' not found on PATH"; exit 1; }; \
+	done
+	@docker info >/dev/null 2>&1 || { echo "error: docker is not running"; exit 1; }
+	@version=$$(oinc version 2>/dev/null | grep -o 'v[0-9][^[:space:]]*' | head -1); \
+	case "$$version" in \
+		$(OINC_VERSION)|$(OINC_VERSION)-*) ;; \
+		*) echo "error: oinc $(OINC_VERSION) required, found $${version:-unknown}"; exit 1 ;; \
+	esac
+
+dynamic-build:
+	yarn install --immutable
+	TURBO_FORCE=1 yarn build
+	cd plugins/kuadrant && yarn export-dynamic
+	cd plugins/kuadrant-backend && yarn export-dynamic
+	docker build -f e2e-tests/rhdh/Dockerfile \
+		--build-arg RHDH_BASE_IMAGE="$(RHDH_BASE_IMAGE)" \
+		-t "$(RHDH_IMAGE)" .
+
+# Kept separate so manual browser testing does not install Playwright.
+e2e-deps:
+	cd e2e-tests && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable
+	cd e2e-tests && yarn playwright install $(PLAYWRIGHT_INSTALL_ARGS) chromium
+
+dynamic-cluster:
+	./oinc/setup-cluster.sh
+	oinc load-image "$(RHDH_IMAGE)"
+	PLUGIN_SOURCE=baked ./oinc/setup-rhdh.sh
+	BASE_URL="$(RHDH_URL)" ./e2e-tests/rhdh/wait-for-catalog.sh
+
+dynamic-up: preflight dynamic-build dynamic-cluster
+	@echo ""
+	@echo "RHDH is ready at $(RHDH_URL) (Dex: $(DEX_URL))."
+	@echo "Run 'make e2e-deps e2e-specs' for the tests, or 'make teardown' when done."
+
+e2e-specs:
+	@curl -fsS -o /dev/null --max-time 10 "$(RHDH_URL)" || { \
+		echo "error: no RHDH responding at $(RHDH_URL); run 'make dynamic-up' first"; \
+		exit 1; \
+	}
+	cd e2e-tests && BASE_URL="$(RHDH_URL)" yarn test $(PLAYWRIGHT_ARGS)
+
+teardown:
+	./oinc/teardown.sh
+
+# Leave a failed local environment running for inspection. CI always invokes the
+# teardown target in its own `if: always()` step.
+e2e-dynamic: preflight dynamic-build e2e-deps
+	@if ! ( $(MAKE) dynamic-cluster && CI=1 $(MAKE) e2e-specs ); then \
+		echo "dynamic e2e failed; the cluster is available for inspection"; \
+		echo "  RHDH: $(RHDH_URL)"; \
+		echo "  logs: kubectl -n rhdh logs -l app.kubernetes.io/component=backstage --all-containers --tail=300"; \
+		echo "  stop: make teardown"; \
+		exit 1; \
+	fi
+	@$(MAKE) teardown

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,13 +2,14 @@
 
 ## Workflows
 
-Three GitHub Actions workflows live in `.github/workflows/`:
+GitHub Actions workflows live in `.github/workflows/`:
 
-| Workflow                     | Trigger                                     | Purpose                                        |
-| ---------------------------- | ------------------------------------------- | ---------------------------------------------- |
-| `ci.yml`                     | PRs, merge queue, pushes to main, or manual | Build, lint, type-check, unit tests, e2e tests |
-| `publish.yml`                | GitHub Release published, or manual         | Publish packages to npm                        |
-| `contributor-governance.yml` | Issues and PRs                              | Run the shared contributor-governance checks   |
+| Workflow                     | Trigger                                     | Purpose                                                      |
+| ---------------------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| `ci.yml`                     | PRs, merge queue, pushes to main, or manual | Build, lint, type-check, unit tests, static-plugin e2e tests |
+| `e2e-dynamic.yml`            | Manual (`workflow_dispatch`)                | Full e2e suite against dynamic plugins in RHDH               |
+| `publish.yml`                | GitHub Release published, or manual         | Publish packages to npm                                      |
+| `contributor-governance.yml` | Issues and PRs                              | Run the shared contributor-governance checks                 |
 
 ## Release Flow
 
@@ -85,9 +86,11 @@ before publication. Without this step, the frontend would be missing
 - **build-validate**: Lint, prettier, type-check, build, verify output bundles exist
 - **export-plugins**: Build and verify the frontend and backend dynamic exports
 - **unittests**: Backend and frontend unit tests
-- **e2e-tests**: Spins up a kind cluster with Kuadrant, starts Backstage, runs Playwright tests
+- **e2e-tests**: Spins up a kind cluster with Kuadrant, starts Backstage with the plugins statically linked, and runs Playwright
 
 E2e test artifacts (Playwright report, videos on failure) are uploaded and retained for 7 days.
+
+The static path remains the default required PR check. The dynamic-plugin workflow is manual-only because it also builds an RHDH image and boots an oinc cluster. It runs the same full Playwright suite against the current branch's exported dynamic plugins. Its build and cluster commands are shared with the local Make targets; see [E2E Testing](e2e-testing.md#running-against-rhdh-dynamic-plugins).
 
 ## npm Trusted Publishing
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -38,6 +38,36 @@ yarn test --grep "Happy Path"          # specific test suite
 yarn test --grep "permissions matrix"  # RBAC tests only
 ```
 
+## Running against RHDH (dynamic plugins)
+
+The required CI job above remains the static-plugin path. The separate `E2E (dynamic plugins)` workflow is manually dispatched and runs the same full suite against the current branch's `export-dynamic` output in RHDH on oinc.
+
+The root Makefile is the shared driver for CI and local use. For a one-shot local run:
+
+```bash
+make e2e-dynamic
+```
+
+This builds and exports both plugins, bakes them into an RHDH image, creates the oinc cluster, runs the suite, and tears down on success. A failed run leaves the cluster up for inspection.
+
+For manual UI testing or repeated spec runs:
+
+```bash
+make dynamic-up              # build and leave RHDH running
+make e2e-deps                # needed once before running Playwright locally
+make e2e-specs               # repeat without rebuilding RHDH
+make teardown
+```
+
+`dynamic-up` deliberately does not install Playwright. RHDH is available at `http://rhdh.localhost:9080`; that `.localhost` origin keeps Web Crypto and clipboard APIs available over HTTP. Both RHDH and `yarn dev` authenticate through Dex with the same personas. See [oinc Development Environment](oinc.md) for the cluster, image, authentication, and version details.
+
+The Make targets require oinc v0.3.1, Docker, Helm, kubectl, curl, Python 3, Node, and Yarn. They install project dependencies but do not install those tools. Version and image defaults can be overridden on the command line, for example:
+
+```bash
+make dynamic-up KUADRANT_VERSION=1.5.1 RHDH_IMAGE_TAG=my-test
+make e2e-specs PLAYWRIGHT_ARGS="--grep 'permissions matrix'"
+```
+
 ## Key Principles
 
 ### 1. Tests verify real behaviour
@@ -137,11 +167,27 @@ npx playwright show-trace test-results/.../trace.zip
 
 ## Test Users
 
-Tests use Dex authentication with these users:
+Tests use Dex authentication with these users in both environments:
+
 - `admin@kuadrant.local` - full permissions
 - `owner1@kuadrant.local` - API owner (can manage own APIs)
 - `owner2@kuadrant.local` - API owner (for ownership isolation tests)
 - `consumer1@kuadrant.local` - API consumer (can request access)
+- `consumer2@kuadrant.local` - API consumer (for isolation tests)
+
+Passwords match the username local part. Personas are defined in `kuadrant-dev-setup/dex/config.yaml`; their catalog users and group membership are in `catalog-entities/kuadrant-users.yaml`, with roles mapped in `rbac-policy.csv`.
+
+## Runtime guards
+
+Kuadrant specs import `test` and `expect` from `playwright/fixtures/test.ts`. The fixture fails a test that sees a Kuadrant backend 5xx, an uncaught page exception, or an unexpected console error. This prevents an empty-state assertion from passing over a failed fetch.
+
+Tests that intentionally stub an error response opt out only for that scope:
+
+```typescript
+test.describe("simulated backend failures", () => {
+  test.use({ allowExpectedErrors: true });
+});
+```
 
 ## Adding testids
 

--- a/docs/kuadrant-resources.md
+++ b/docs/kuadrant-resources.md
@@ -221,6 +221,10 @@ When OIDC is detected, the UI renders an `OidcProviderCard` component that shows
 
 See [`plugins/kuadrant/src/components/OidcProviderCard/OidcProviderCard.tsx`](../plugins/kuadrant/src/components/OidcProviderCard/OidcProviderCard.tsx) for the card implementation.
 
+### API Keys Tab and Card Gating
+
+The entity provider emits `kuadrant.io/auth-apikey: "true"` only when an API-key scheme is discovered. OIDC-only products omit it. This is intentionally presence-based: RHDH dynamic-plugin `hasAnnotation` conditions do not inspect the value, so emitting `"false"` would still show the API Keys tab and overview card. Static mode's `=== "true"` check remains compatible with an absent annotation.
+
 ## PublishStatus for APIProducts
 
 APIProducts have a Draft/Published workflow:

--- a/docs/oinc.md
+++ b/docs/oinc.md
@@ -1,141 +1,133 @@
 # oinc Development Environment
 
-[oinc](https://github.com/jasonmadigan/oinc) (OpenShift in a Container) provides a lightweight OpenShift-compatible cluster for testing the Kuadrant plugins with RHDH dynamic plugins.
-
-This is an alternative to `kuadrant-dev-setup/` (kind cluster + `yarn dev`), not something you run alongside it. Use `kuadrant-dev-setup/` when you're developing plugins and want hot reload. Use oinc when you want to test with stock RHDH and dynamic plugins.
+[oinc](https://github.com/jasonmadigan/oinc) provides a lightweight
+OpenShift-compatible cluster for testing the Kuadrant plugins in Red Hat Developer Hub
+(RHDH). Use the kind + `yarn dev` path for hot reload; use oinc to exercise RHDH's
+dynamic-plugin loading.
 
 ## Prerequisites
 
-- [oinc](https://github.com/jasonmadigan/oinc)
+- oinc v0.3.1
 - kubectl
-- helm
+- Helm
 - npm
-- Docker or Podman
+- Docker or Podman (`make dynamic-up` specifically uses Docker)
 
-Recommended 8GB+ RAM. The full stack (Istio, Kuadrant, RHDH, PostgreSQL) is heavy.
+Allow at least 8 GB of RAM for MicroShift, Istio, Kuadrant, RHDH, and PostgreSQL.
 
 ## Usage
 
 ```bash
-# full setup: cluster + RHDH
-yarn oinc
-
-# cluster only: kuadrant, gateway api, istio, metallb, console, demo resources
-yarn oinc:cluster
-
-# RHDH only: install on existing cluster from oinc:cluster
-yarn oinc:rhdh
-
-# teardown
+yarn oinc           # cluster, Dex, and RHDH with published plugins
+yarn oinc:cluster   # cluster and demo resources only
+yarn oinc:rhdh      # Dex and RHDH on an existing oinc cluster
 yarn oinc:teardown
 ```
 
-## Modes
+RHDH is exposed at `http://rhdh.localhost:9080/kuadrant`; the OpenShift Console is
+available at `http://localhost:9000`.
 
-### Cluster only (`yarn oinc:cluster`)
+## Cluster setup
 
-Creates an oinc cluster with the full Kuadrant infrastructure stack. Gets you to the **starting point** of the [installation guide](installation.md) -- a cluster with all prerequisites installed, ready for RHDH.
-
-The `oinc create --addons kuadrant` command handles the bulk of the work: Gateway API CRDs, cert-manager, MetalLB, Istio (Sail Operator), Kuadrant Operator, OLM, and the OpenShift Console.
-
-Our setup script then adds:
-- MetalLB IP address pool (auto-detected from the container bridge network)
-- Gateway resource (`kuadrant-ingressgateway` in `gateway-system`)
-- Demo resources from `kuadrant-dev-setup/demo/`
-
-After setup, the OpenShift Console is available at http://localhost:9000.
-
-### RHDH (`yarn oinc:rhdh`)
-
-Installs RHDH on an existing cluster from `oinc:cluster`. Gets you to the **end state** of the [installation guide](installation.md) -- RHDH running with Kuadrant dynamic plugins configured.
-
-Configures: RHDH service account, RBAC policies, dynamic plugins (frontend + backend + RBAC management UI), guest auth, extensions installation UI.
-
-After setup:
-```bash
-kubectl port-forward svc/rhdh-developer-hub 7007:7007 -n rhdh
-# http://localhost:7007/kuadrant
-```
-
-## What oinc provides vs what we add
-
-oinc gives you MicroShift in a container with OLM, OpenShift Console (port 9000), and a ConsolePlugin CRD out of the box. The `--addons kuadrant` flag installs the full Kuadrant stack and all its dependencies via topological dependency resolution.
-
-Our setup scripts add:
-
-**`setup-cluster.sh` adds:**
-
-| Component | Notes |
-|-|-|
-| MetalLB IP pool | Auto-detected from container bridge subnet (.200-.220 range) |
-| Gateway resource | `kuadrant-ingressgateway` in `gateway-system`, istio gatewayClass |
-| Demo resources | APIProducts, PlanPolicies from `kuadrant-dev-setup/demo/` |
-
-**`setup-rhdh.sh` adds:**
-
-| Component | Source | Notes |
-|-|-|-|
-| RHDH (Helm chart) | `rhdh/backstage` | Stock RHDH image with dynamic plugins |
-| Kuadrant plugins | npm packages | Frontend + backend, integrity hashes fetched at setup time |
-| RBAC management UI | Bundled in RHDH image | `backstage-community-plugin-rbac`, just enabled |
-| RHDH service account | `oinc/manifests/rhdh-sa.yaml` | ClusterRole for Kuadrant CRDs |
-| Guest auth + RBAC | ConfigMaps | Guest user gets `api-admin` role for local dev |
-| Extensions UI | app-config + seed file | Enables the plugin management UI in RHDH |
-
-## File structure
-
-```
-oinc/
-  setup.sh              # entry point, dispatches to modes
-  setup-cluster.sh      # oinc create + post-setup (MetalLB pool, Gateway, demos)
-  setup-rhdh.sh         # RHDH installation
-  teardown.sh           # deletes the oinc cluster
-  lib.sh                # shared helpers
-  manifests/
-    rhdh-sa.yaml        # RHDH service account + RBAC
-```
-
-## Differences from `yarn dev`
-
-| | `yarn dev` (kind) | `yarn oinc` (oinc) |
-|-|-|-|
-| Plugins | Static (built into app) | Dynamic (npm packages) |
-| Hot reload | Yes | No (uses published packages) |
-| RHDH image | N/A (standalone Backstage) | Stock RHDH |
-| Use case | Plugin development | Integration testing, installation guide validation |
-
-## Running e2e tests against oinc
-
-With RHDH running and port-forwarded:
+`oinc/setup-cluster.sh` runs:
 
 ```bash
-kubectl port-forward svc/rhdh-developer-hub 7007:7007 -n rhdh
+oinc create --version 4.21 --addons kuadrant@1.5.1 \
+  --kuadrant-devportal \
+  --metallb-address-pool auto \
+  --gateway-api-gateway
 ```
 
-Run the e2e tests with `BASE_URL` pointed at port 7007 (the default is 3000 for `yarn dev`):
+oinc installs Gateway API, cert-manager, MetalLB, Istio, Kuadrant, OLM, and the
+OpenShift Console. The options enable the developer portal and create the address pool
+and default gateway. The repository script then applies the demo resources used by the
+catalog and tests. oinc also merges the cluster kubeconfig during `create`.
+
+`OCP_VERSION` and `KUADRANT_VERSION` override the pinned defaults:
 
 ```bash
-cd e2e-tests
-BASE_URL=http://localhost:7007 yarn test
+OCP_VERSION=4.21 KUADRANT_VERSION=1.5.1 yarn oinc:cluster
 ```
+
+## RHDH setup
+
+`oinc/setup-rhdh.sh` installs Dex first, then installs RHDH through the oinc `rhdh`
+addon. Its values overlay configures:
+
+- the Kuadrant frontend and backend dynamic plugins;
+- frontend routes, menu items, entity tabs, and cards;
+- the Kubernetes service-account connection;
+- the catalog users and RBAC policy;
+- Dex OIDC sign-in; and
+- the extensions installation UI.
+
+The default `PLUGIN_SOURCE=npm` loads the published Kuadrant packages and resolves their
+integrity hashes. The dynamic test path uses `PLUGIN_SOURCE=baked`; it builds the current
+branch's exported plugins into a derived RHDH image and sideloads that image with
+`oinc load-image`.
+
+The RHDH chart defaults to 6.2.2 and the image line to
+`quay.io/rhdh-community/rhdh:1.10`. `RHDH_CHART_VERSION`, `RHDH_IMAGE_REPOSITORY`, and
+`RHDH_IMAGE_TAG` are overridable.
+
+## Authentication
+
+Both `yarn dev` and the oinc RHDH path use Dex v2.45.1 and the same five personas:
+
+| User                       | Role           |
+| -------------------------- | -------------- |
+| `admin@kuadrant.local`     | `api-admin`    |
+| `owner1@kuadrant.local`    | `api-owner`    |
+| `owner2@kuadrant.local`    | `api-owner`    |
+| `consumer1@kuadrant.local` | `api-consumer` |
+| `consumer2@kuadrant.local` | `api-consumer` |
+
+Passwords match the username local part. Dex users and clients live in
+`kuadrant-dev-setup/dex/config.yaml`; Backstage users and group membership live in
+`catalog-entities/kuadrant-users.yaml`; `rbac-policy.csv` maps those groups to roles.
+
+The oinc issuer is `http://dex.localhost:9080`. On the host, `.localhost` reaches the
+oinc ingress. In a pod, Kubernetes expands `dex.localhost` to the `dex` Service in the
+`localhost` Namespace. Using one resolvable name matters because the token issuer cannot
+differ between browser and backend.
+
+On Linux hosts that do not synthesize `.localhost`, add explicit IPv4 entries:
+
+```bash
+echo "127.0.0.1 rhdh.localhost" | sudo tee -a /etc/hosts
+echo "127.0.0.1 dex.localhost" | sudo tee -a /etc/hosts
+```
+
+## Kubernetes RBAC
+
+The canonical ClusterRole is
+`kuadrant-dev-setup/rbac/rhdh-cluster-role.yaml`. The kind and oinc manifests contain
+only their environment-specific service accounts and bindings, so permission changes
+cannot drift between the two paths.
+
+## Testing the current branch dynamically
+
+Use the root Make targets rather than the published-package `yarn oinc` path:
+
+```bash
+make dynamic-up
+make e2e-deps
+make e2e-specs
+make teardown
+```
+
+`make e2e-dynamic` performs the same phases as a one-shot run. See
+[E2E Testing](e2e-testing.md#running-against-rhdh-dynamic-plugins).
 
 ## Troubleshooting
 
-Check pod status:
 ```bash
+oinc status --watch
 kubectl -n rhdh get pods
 kubectl -n rhdh logs deployment/rhdh-developer-hub
-```
-
-Init container logs (plugin installation):
-```bash
 kubectl -n rhdh logs deployment/rhdh-developer-hub -c install-dynamic-plugins
+kubectl -n localhost logs deployment/dex
 ```
 
-If RHDH is stuck in init, it's usually downloading plugins. The init container fetches all default RHDH plugins plus the Kuadrant ones from npm.
-
-Cluster status:
-```bash
-oinc status          # endpoints and addon status
-oinc status --watch  # live dashboard
-```
+The RHDH init container downloads or copies dynamic plugins before the backend starts,
+so a fresh install can remain in init for several minutes.

--- a/docs/rbac-permissions.md
+++ b/docs/rbac-permissions.md
@@ -461,21 +461,17 @@ See `app-config.local.yaml`:
 permission:
   enabled: true
   rbac:
-    policies-csv-file: ./rbac-policy.csv
+    policies-csv-file: ../../rbac-policy.csv
     policyFileReload: true
 ```
 
 ### Testing Different Roles
 
-Use the included helper scripts:
+`yarn dev` runs a local dex container on `:5556`. Sign in through the dex quick-login picker as one of five personas: `admin@kuadrant.local`, `owner1@`, `owner2@`, `consumer1@`, `consumer2@`. Sign out and back in to switch.
 
-```bash
-yarn user:consumer  # switch to API Consumer role
-yarn user:owner     # switch to API Owner role
-yarn user:default   # restore default permissions
-```
+Dex credentials are defined in `kuadrant-dev-setup/dex/config.yaml`. The matching catalog users and their group membership (`api-admins`, `api-owners`, `api-consumers`) live in `catalog-entities/kuadrant-users.yaml`, and `rbac-policy.csv` maps those groups to roles.
 
-After switching roles, restart with `yarn dev`.
+The Kubernetes permissions used by both kind and oinc are defined once in `kuadrant-dev-setup/rbac/rhdh-cluster-role.yaml`; each environment supplies only its service account and binding.
 
 ## Security Considerations
 

--- a/e2e-tests/playwright/e2e/kuadrant-auth-schemes.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-auth-schemes.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures/test";
 import { Common } from "../utils/common";
 import { TIMEOUTS, isElementVisible } from "../utils/kuadrant-helpers";
 
@@ -23,7 +23,7 @@ test.describe("Auth Scheme UI Behaviour", () => {
 
   test.beforeEach(async ({ page }) => {
     common = new Common(page);
-    await common.loginAsGuest();
+    await common.dexQuickLogin("admin@kuadrant.local");
   });
 
   test.describe("OIDC-only API (gamestore-api)", () => {

--- a/e2e-tests/playwright/e2e/kuadrant-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-happy-path.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures/test";
 import { Common } from "../utils/common";
 import {
   TIMEOUTS,
+  apiKeyTableTotal,
   createTestAPIProductData,
   waitForKuadrantPageReady,
   waitForApiKeysPageReady,
@@ -38,55 +39,59 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
   test.afterAll(async ({ browser }) => {
     if (!testCreated) return;
 
+    const context = await browser.newContext();
     try {
-      const context = await browser.newContext();
       const page = await context.newPage();
       const common = new Common(page);
 
       await common.dexQuickLogin("owner1@kuadrant.local");
       await page.goto("/kuadrant/api-products");
 
-      const heading = page
-        .locator("h1, h2")
-        .filter({ hasText: /api products/i })
-        .first();
-      await heading
-        .waitFor({ state: "visible", timeout: TIMEOUTS.SLOW })
-        .catch(() => {});
+      // wait for the table, not just the heading: searching before the rows
+      // arrive filters an empty table and finds nothing.
+      await waitForKuadrantPageReady(page);
 
-      const apiProductRow = page
-        .locator("tr")
-        .filter({ hasText: testData.displayName });
-      const rowVisible = await apiProductRow.isVisible().catch(() => false);
-
-      if (rowVisible) {
-        const deleteButton = apiProductRow.getByRole("button", {
-          name: /delete api product/i,
-        });
-        await deleteButton.click();
-
-        const confirmDialog = page.getByRole("dialog");
-        const dialogVisible = await confirmDialog
-          .isVisible()
-          .catch(() => false);
-
-        if (dialogVisible) {
-          const confirmInput = confirmDialog.getByRole("textbox");
-          await confirmInput.fill(testData.name);
-
-          const confirmButton = confirmDialog.getByRole("button", {
-            name: /delete/i,
-          });
-          await confirmButton.click();
-          await confirmDialog
-            .waitFor({ state: "hidden", timeout: TIMEOUTS.SLOW })
-            .catch(() => {});
-        }
+      // narrow before looking: the products table pages at 20, so past that the
+      // row is simply not on screen and the old isVisible() check quietly
+      // decided there was nothing to clean up. that is why a long-lived cluster
+      // fills with leftover e2e-test-api-* products, which then pages the demo
+      // products the other specs look for off their own first page.
+      const search = page.getByRole("textbox", { name: "Search" });
+      if (await search.count()) {
+        await search.fill(testData.name);
       }
 
-      await context.close();
+      // matched on the id, which both name and displayName carry: the search
+      // indexes the resource name, but the row renders the display name.
+      const apiProductRow = page
+        .locator("tbody tr")
+        .filter({ hasText: testData.id })
+        .first();
+      await apiProductRow.waitFor({ state: "visible", timeout: TIMEOUTS.SLOW });
+
+      await apiProductRow
+        .getByRole("button", { name: /delete api product/i })
+        .click();
+
+      const confirmDialog = page.getByRole("dialog");
+      await confirmDialog.waitFor({
+        state: "visible",
+        timeout: TIMEOUTS.DEFAULT,
+      });
+      await confirmDialog.getByRole("textbox").fill(testData.name);
+      await confirmDialog.getByRole("button", { name: /delete/i }).click();
+      await confirmDialog.waitFor({ state: "hidden", timeout: TIMEOUTS.SLOW });
     } catch (error) {
-      console.warn("Cleanup failed:", error);
+      // a failed cleanup leaks a product into the cluster, so say so loudly
+      // enough to be found in a log rather than filing it under "warning", and
+      // fail the suite rather than let a leak pass silently.
+      console.error(
+        `Cleanup failed - ${testData.name} is still on the cluster:`,
+        error,
+      );
+      throw error;
+    } finally {
+      await context.close();
     }
   });
 
@@ -124,7 +129,16 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
     // select an HTTPRoute
     const httprouteSelect = page.locator('[data-testid="httproute-select"]');
     await httprouteSelect.scrollIntoViewIfNeeded();
-    await httprouteSelect.click({ timeout: TIMEOUTS.DEFAULT });
+    // disabled while the routes load, and a click on a disabled MUI Select is
+    // swallowed - the failure then reads as "options never appeared". the open
+    // is retried because a re-render as the fetch settles can dismiss the menu.
+    await expect(httprouteSelect).toBeEnabled({ timeout: TIMEOUTS.SLOW });
+    await expect(async () => {
+      await httprouteSelect.click({ timeout: TIMEOUTS.DEFAULT });
+      await expect(
+        page.getByRole("listbox").getByRole("option").first(),
+      ).toBeVisible({ timeout: TIMEOUTS.QUICK });
+    }).toPass({ timeout: TIMEOUTS.SLOW, intervals: [250, 500, 1000] });
 
     // wait for dropdown options and select toystore
     const toystoreOption = page
@@ -145,7 +159,13 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
     });
     testCreated = true;
 
-    // verify API product appears in table (scope to table to avoid matching toast)
+    // verify API product appears in table (scope to table to avoid matching
+    // toast). narrowed first: the table pages at 20, so a newly created product
+    // is not necessarily on the visible page.
+    const search = page.getByRole("textbox", { name: "Search" });
+    if (await search.count()) {
+      await search.fill(testData.name);
+    }
     const table = page.locator("table");
     const apiProductRow = table.getByRole("link", {
       name: testData.displayName,
@@ -218,7 +238,8 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
       timeout: TIMEOUTS.DEFAULT,
     });
 
-    // click the select to open dropdown
+    // click the select to open dropdown, once the plans have loaded
+    await expect(tierSelect).toBeEnabled({ timeout: TIMEOUTS.SLOW });
     await tierSelect.click();
 
     // wait for dropdown and select first option
@@ -261,10 +282,19 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
     await page.goto("/kuadrant/api-key-approval");
     await waitForApiKeysPageReady(page);
 
-    // should see consumer1's request in the approval queue table
-    const consumerRequest = page.getByText(/consumer1/i).first();
+    // should see consumer1's request in the approval queue. narrowed to the api
+    // step 3 requested against - toystore-api, not the product created in step
+    // 1 - because the queue pages at 20 and on a reused cluster the newest
+    // request is not reliably on the visible page.
+    const search = page.getByRole("textbox", { name: "Search" });
+    if (await search.count()) {
+      await search.fill("toystore-api");
+    }
     await expect(
-      consumerRequest,
+      page
+        .locator("tbody tr")
+        .filter({ hasText: /consumer1/i })
+        .first(),
       "Admin should see consumer1's request",
     ).toBeVisible({ timeout: TIMEOUTS.SLOW });
   });
@@ -277,12 +307,28 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
     await page.goto("/kuadrant/api-key-approval");
     await waitForApiKeysPageReady(page);
 
-    // owner2 should NOT see toystore requests (toystore is owned by owner1)
-    // verify the table shows no API keys
-    const noApiKeysMessage = page.getByText(/no api keys found/i);
+    // owner2 should NOT see requests for owner1's api. the claim is about that
+    // api, not about owner2's queue being empty overall - owner2 owns other
+    // demo apis, so requests for those are legitimately there and asserting a
+    // globally empty queue only held while nothing else had ever been
+    // requested. narrow to owner1's product and assert nothing comes back.
+    const search = page.getByRole("textbox", { name: "Search" });
+    if (await search.count()) {
+      await search.fill(testData.name);
+    }
     await expect(
-      noApiKeysMessage,
-      "Owner2 should see 'No API keys found' (toystore owned by owner1)",
+      page.locator("tbody tr").filter({ hasText: testData.name }),
+      "Owner2 should see no requests for owner1's api",
+    ).toHaveCount(0, { timeout: TIMEOUTS.DEFAULT });
+    // and the page says so, rather than the count being zero because nothing
+    // rendered: an empty queue shows "No API keys found", a search that matches
+    // nothing shows the table's own "No records to display".
+    await expect(
+      page
+        .getByText(/no api keys found/i)
+        .or(page.getByText(/no records to display/i))
+        .first(),
+      "the queue should report nothing matching owner1's api",
     ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
   });
 
@@ -387,12 +433,21 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
     await page.goto("/kuadrant/my-api-keys");
     await waitForApiKeysPageReady(page);
 
-    // find the first row in the table
-    const firstRow = page.locator("table tbody tr").first();
+    // rows for the same api product are indistinguishable in the dom, and the
+    // table pages at 20 - so counting visible rows proves nothing once the
+    // first page is full (deleting one just pulls the next row up), and
+    // asserting the table ends up empty only held while this was consumer1's
+    // only key ever. the pagination footer carries the real total, so use that
+    // where it is rendered (material-table only pages past 10 rows).
+    const totalKeys = () => apiKeyTableTotal(page);
+
+    const rows = page.locator("table tbody tr");
+    const firstRow = rows.first();
     await expect(
       firstRow,
       "Consumer should see at least one API key",
     ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+    const before = await totalKeys();
 
     // click the delete button in the Actions column
     const deleteButton = firstRow.getByRole("button", { name: /delete/i });
@@ -433,11 +488,12 @@ test.describe("Kuadrant Happy Path - Full API Lifecycle", () => {
       timeout: TIMEOUTS.DEFAULT,
     });
 
-    // verify the key is removed — table should be empty after deleting the only key
-    const emptyState = page.getByText(/no api keys found/i);
-    await expect(
-      emptyState,
-      "Table should show empty state after deleting the only key",
-    ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+    // exactly one key fewer
+    await expect
+      .poll(totalKeys, {
+        timeout: TIMEOUTS.SLOW,
+        message: "Deleting one key should leave exactly one fewer",
+      })
+      .toBe(before - 1);
   });
 });

--- a/e2e-tests/playwright/e2e/kuadrant-live-backend.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-live-backend.spec.ts
@@ -1,0 +1,242 @@
+import { test, expect, Page } from "../fixtures/test";
+import { Common } from "../utils/common";
+import { TIMEOUTS, waitForApiKeysPageReady } from "../utils/kuadrant-helpers";
+
+/**
+ * Specs that go all the way through to the real backend and the cluster.
+ *
+ * The rest of the dynamic set asserts that pages render, which a page can do
+ * perfectly well while every request behind it fails: the approvals table
+ * swallows a failed fetch into a transient alert and then draws the same empty
+ * table it draws when the queue really is empty. These deliberately do not
+ * page.route the kuadrant endpoints, and assert on the responses rather than
+ * only on the DOM, so a 500 or a missing RBAC rule cannot pass as an empty
+ * state.
+ *
+ * Serial: the copy test reads the key the request test creates.
+ */
+test.describe.serial("Kuadrant against the live backend", () => {
+  // owner1-inventory-api is the demo's automatic-approval product
+  // (kuadrant-dev-setup/demo/additional-demos.yaml), so requesting access
+  // yields an Approved APIKey without a second persona to approve it.
+  const autoApproveApi = "owner1-inventory-api";
+
+  const requestsPath = "/api/kuadrant/requests";
+  const isRequestsCall = (url: string, expected: string) =>
+    new URL(url).pathname === expected;
+
+  // make dynamic-up reuses a cluster, so the table carries rows from earlier
+  // runs and from every other product. narrow to the rows this spec cares about
+  // before picking one: the row that sorts first is as likely to be a stale
+  // Pending one, and a key that is not Approved has no code examples card to
+  // find. taking .first() of an already-narrowed set is fine - every row in it
+  // satisfies what the assertion is about.
+  const rowsForApi = (page: Page) =>
+    page
+      .getByRole("row")
+      .filter({ has: page.getByRole("cell", { name: autoApproveApi }) });
+
+  // the status column labels an Approved key "Active"
+  const approvedRowsForApi = (page: Page) =>
+    rowsForApi(page).filter({ has: page.getByText("Active", { exact: true }) });
+
+  test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.annotations.push({
+      type: "component",
+      description: "kuadrant",
+    });
+  });
+
+  // the keys table pages at 20 and a reused cluster accumulates rows, so the
+  // row this spec is looking for is not reliably on the visible page. narrowing
+  // is a no-op when the table is small enough not to render a search box.
+  const narrowToApi = async (page: Page) => {
+    const search = page.getByRole("textbox", { name: "Search" });
+    if (await search.count()) {
+      await search.fill(autoApproveApi);
+    }
+  };
+
+  test.beforeEach(async ({ page }) => {
+    const common = new Common(page);
+    await common.dexQuickLogin("admin@kuadrant.local");
+  });
+
+  // guards the origin itself. on a non-secure origin these three are undefined,
+  // which takes out requesting a key (crypto.randomUUID) and every copy button
+  // (navigator.clipboard) while every page still renders.
+  test("serves a secure context, so web crypto and clipboard exist", async ({
+    page,
+  }) => {
+    await page.goto("/kuadrant/my-api-keys");
+    await waitForApiKeysPageReady(page);
+
+    const capabilities = await page.evaluate(() => ({
+      secureContext: window.isSecureContext,
+      randomUUID: typeof window.crypto?.randomUUID,
+      subtle: typeof window.crypto?.subtle,
+      clipboard: typeof navigator.clipboard?.writeText,
+    }));
+
+    expect(capabilities).toEqual({
+      secureContext: true,
+      randomUUID: "function",
+      subtle: "object",
+      clipboard: "function",
+    });
+  });
+
+  test("approvals page loads the request queue from the backend", async ({
+    page,
+  }) => {
+    // arm before navigating: the fetch goes out as the page mounts
+    const requestsCall = page.waitForResponse(
+      (response) =>
+        isRequestsCall(response.url(), requestsPath) &&
+        response.request().method() === "GET",
+      { timeout: TIMEOUTS.VERY_SLOW },
+    );
+
+    await page.goto("/kuadrant/api-key-approval");
+
+    // the assertion that matters: without rbac for apikeyrequests this is a
+    // 500 and the table below still renders, empty and apparently fine.
+    const response = await requestsCall;
+    expect(response.status(), "GET /api/kuadrant/requests should succeed").toBe(
+      200,
+    );
+
+    await waitForApiKeysPageReady(page);
+
+    // the fetch failure surfaces only as this transient alert
+    await expect(page.getByText(/failed to get resources/i)).toHaveCount(0);
+
+    // the data region resolved to real content: either the queue table or the
+    // explicit empty state, never a spinner or an error panel
+    const dataRegion = page
+      .locator("table")
+      .or(page.getByText(/no api keys found/i));
+    await expect(dataRegion.first()).toBeVisible({ timeout: TIMEOUTS.SLOW });
+  });
+
+  test("requesting access creates the request through the backend", async ({
+    page,
+  }) => {
+    await page.goto("/kuadrant/my-api-keys");
+    await waitForApiKeysPageReady(page);
+
+    const dialog = page.getByRole("dialog");
+
+    // fill the dialog, reopening it if the tiers are not there yet: they come
+    // from the PlanPolicy's discovered plans, so they exist only once the
+    // operator has reconciled it, and the dialog reads the products once when
+    // it opens. reopening is what picks them up, so retry the whole thing
+    // rather than racing the first paint.
+    await expect(async () => {
+      if (await dialog.isVisible()) {
+        await dialog.getByTestId("cancel-button").click();
+        await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.QUICK });
+      }
+
+      await page.getByTestId("request-access-button").click();
+      await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
+
+      // the testid sits on the MUI input wrapper; the thing that opens the
+      // menu is the role=button inside it, so clicking the wrapper only
+      // focuses it.
+      await dialog.getByTestId("api-select").getByRole("button").click();
+      await page
+        .getByRole("listbox")
+        .getByRole("option", { name: autoApproveApi, exact: true })
+        .click();
+
+      const tierSelect = dialog.getByTestId("tier-select").getByRole("button");
+      await expect(tierSelect).toBeEnabled({ timeout: TIMEOUTS.QUICK });
+      await tierSelect.click();
+
+      const tierOption = page
+        .getByRole("listbox")
+        .getByRole("option")
+        .filter({ hasNotText: /no tiers available/i })
+        .first();
+      await expect(tierOption).toBeVisible({ timeout: TIMEOUTS.QUICK });
+      await tierOption.click();
+    }).toPass({ timeout: TIMEOUTS.VERY_SLOW, intervals: [1000, 2000, 5000] });
+
+    await dialog
+      .getByTestId("usecase-input")
+      .fill("e2e: request access against the live backend");
+
+    // exercises crypto.randomUUID, which is undefined off a secure context
+    const created = page.waitForResponse(
+      (response) =>
+        isRequestsCall(response.url(), requestsPath) &&
+        response.request().method() === "POST",
+      { timeout: TIMEOUTS.VERY_SLOW },
+    );
+
+    await dialog.getByTestId("submit-button").click();
+
+    const response = await created;
+    expect(
+      response.status(),
+      "POST /api/kuadrant/requests should create the request",
+    ).toBe(201);
+
+    await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.SLOW });
+
+    // and it came back into the table the page refetched. the 201 above is what
+    // proves this run created the request; what matters here is that the table
+    // round-trip reaches the state the next test needs - an Approved key for
+    // this api, which the automatic product yields without a reviewer. a row
+    // that is merely present is not enough: a Pending one has no code examples
+    // card, and on a reused cluster it is as likely to be the one found.
+    await expect(async () => {
+      await narrowToApi(page);
+      await expect(approvedRowsForApi(page).first()).toBeVisible({
+        timeout: TIMEOUTS.QUICK,
+      });
+    }).toPass({ timeout: TIMEOUTS.VERY_SLOW, intervals: [1000, 2000, 5000] });
+  });
+
+  test("copying a code example writes it to the clipboard", async ({
+    page,
+  }) => {
+    await page.goto("/kuadrant/my-api-keys");
+    await waitForApiKeysPageReady(page);
+
+    // open an Approved key for the api the previous test requested. the row's
+    // product cell links to the catalog entity, so go through the row action,
+    // which is what opens the key detail page and its code examples card. the
+    // card is rendered only for an Approved key, which the automatic product
+    // yields without a reviewer - so scope to those rows rather than taking
+    // whichever row happens to sort first, which on a reused cluster is as
+    // likely to be Pending, leaving the card below to time out saying nothing.
+    await narrowToApi(page);
+    const approvedRow = approvedRowsForApi(page).first();
+    await expect(approvedRow).toBeVisible({ timeout: TIMEOUTS.VERY_SLOW });
+    await approvedRow.getByRole("button", { name: "View details" }).click();
+
+    await page.waitForURL(/\/kuadrant\/api-keys\/[^/]+\/[^/]+/, {
+      timeout: TIMEOUTS.SLOW,
+    });
+
+    // pick the tab by name: the assertion below is about the curl example, and
+    // the tab order is the component's business, not this test's
+    await page.getByRole("tab", { name: "cURL" }).click();
+
+    const copyButton = page.getByRole("button", { name: /copy code/i });
+    await expect(copyButton).toBeVisible({ timeout: TIMEOUTS.VERY_SLOW });
+    await copyButton.click();
+
+    await expect(page.getByText(/copied to clipboard/i).first()).toBeVisible({
+      timeout: TIMEOUTS.DEFAULT,
+    });
+
+    // the snackbar fires whether or not the write landed, so read it back
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain("curl");
+  });
+});

--- a/e2e-tests/playwright/e2e/kuadrant-permissions-matrix.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-permissions-matrix.spec.ts
@@ -1,10 +1,32 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "../fixtures/test";
 import { Common } from "../utils/common";
 import {
   TIMEOUTS,
   expectButtonPermission,
   waitForKuadrantPageReady,
+  waitForApiKeysPageReady,
+  seedPendingApiKeyRequest,
+  generateTestId,
 } from "../utils/kuadrant-helpers";
+
+// demo APIProducts seeded by setup-cluster.sh, named so a test can seed a
+// request against an api with a known owner.
+const owner1Api = "owner1-inventory-api";
+const owner2Api = "owner2-shipping-api";
+
+/**
+ * Filter the API Products table down to one product.
+ *
+ * The table pages at 20 rows, and the environment grows products over time, so
+ * a named row is not reliably on the first page. Searching is a no-op when the
+ * table is small enough not to render a search box.
+ */
+async function narrowProductsTable(page: Page, text: string): Promise<void> {
+  const search = page.getByRole("textbox", { name: "Search" });
+  if (await search.count()) {
+    await search.fill(text);
+  }
+}
 
 /**
  * Comprehensive permissions matrix test.
@@ -163,25 +185,27 @@ test.describe("Kuadrant Permissions Matrix", () => {
         timeout: TIMEOUTS.DEFAULT,
       });
 
-      // find Gamestore API row specifically (owned by owner2, not owner1)
+      // find Gamestore API row specifically (owned by owner2, not owner1).
+      // it is seeded by setup-cluster.sh, so its absence is a broken
+      // environment, not a reason to skip the assertion this test exists for.
+      await narrowProductsTable(page, "Gamestore API");
       const gamestoreRow = page
         .locator("tr")
         .filter({ hasText: "Gamestore API" })
         .first();
-      const gamestoreVisible = await gamestoreRow
-        .isVisible()
-        .catch(() => false);
+      await expect(
+        gamestoreRow,
+        "Gamestore API should be listed for owner1 to read",
+      ).toBeVisible({ timeout: TIMEOUTS.SLOW });
 
-      if (gamestoreVisible) {
-        // owner1 should NOT see edit button on Gamestore API (owned by owner2)
-        const gamestoreEditBtn = gamestoreRow.getByRole("button", {
-          name: /edit api product/i,
-        });
-        await expect(
-          gamestoreEditBtn,
-          "Owner should NOT see edit button on other's products",
-        ).not.toBeVisible({ timeout: TIMEOUTS.QUICK });
-      }
+      // owner1 should NOT see edit button on Gamestore API (owned by owner2)
+      const gamestoreEditBtn = gamestoreRow.getByRole("button", {
+        name: /edit api product/i,
+      });
+      await expect(
+        gamestoreEditBtn,
+        "Owner should NOT see edit button on other's products",
+      ).not.toBeVisible({ timeout: TIMEOUTS.QUICK });
     });
 
     test("kuadrant.apiproduct.delete.all - admin CAN delete any product", async ({
@@ -311,10 +335,21 @@ test.describe("Kuadrant Permissions Matrix", () => {
 
     test("kuadrant.apikey.approve - admin CAN see approval page", async ({
       page,
+      browser,
     }) => {
+      // seed a request first: a heading renders whether or not the admin can
+      // actually read anyone's requests, so the heading alone proved nothing.
+      // owner2's api, to show the admin is not limited to their own.
+      await seedPendingApiKeyRequest(
+        browser,
+        `admin sees pending ${generateTestId()}`,
+        owner2Api,
+      );
+
       const common = new Common(page);
       await common.dexQuickLogin("admin@kuadrant.local");
       await page.goto("/kuadrant/api-key-approval");
+      await waitForApiKeysPageReady(page);
 
       const heading = page
         .locator("h1, h2")
@@ -323,14 +358,33 @@ test.describe("Kuadrant Permissions Matrix", () => {
         heading.first(),
         "Admin should see API Key Approval page",
       ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+
+      // the queue pages at 20 rows, so narrow to the seeded api first -
+      // otherwise a fresh request can sit off the visible page.
+      await page.getByRole("textbox", { name: "Search" }).fill(owner2Api);
+
+      await expect(
+        page.locator("tbody tr").filter({ hasText: owner2Api }).first(),
+        "Admin should see the consumer's pending request for owner2's api",
+      ).toBeVisible({ timeout: TIMEOUTS.VERY_SLOW });
     });
 
     test("kuadrant.apikey.approve - owner CAN see approval page", async ({
       page,
+      browser,
     }) => {
+      // owner1's own api: an approval queue only carries requests for apis the
+      // approver owns, so seeding against anything else proves nothing here.
+      await seedPendingApiKeyRequest(
+        browser,
+        `owner sees pending ${generateTestId()}`,
+        owner1Api,
+      );
+
       const common = new Common(page);
       await common.dexQuickLogin("owner1@kuadrant.local");
       await page.goto("/kuadrant/api-key-approval");
+      await waitForApiKeysPageReady(page);
 
       const heading = page
         .locator("h1, h2")
@@ -339,6 +393,15 @@ test.describe("Kuadrant Permissions Matrix", () => {
         heading.first(),
         "Owner should see API Key Approval page",
       ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+
+      // the queue pages at 20 rows, so narrow to the seeded api first -
+      // otherwise a fresh request can sit off the visible page.
+      await page.getByRole("textbox", { name: "Search" }).fill(owner1Api);
+
+      await expect(
+        page.locator("tbody tr").filter({ hasText: owner1Api }).first(),
+        "Owner should see the pending request for their own api",
+      ).toBeVisible({ timeout: TIMEOUTS.VERY_SLOW });
     });
 
     test("kuadrant.apikey.approve - consumer CANNOT access approval page", async ({
@@ -414,7 +477,10 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.goto("/kuadrant/api-products");
       await waitForKuadrantPageReady(page);
 
-      // Toystore API must exist for this test (owned by owner1)
+      // Toystore API must exist for this test (owned by owner1). the products
+      // table pages at 20, so narrow to it first rather than hoping it landed
+      // on the visible page.
+      await narrowProductsTable(page, "Toystore API");
       const toystoreRow = page
         .locator("tr")
         .filter({ hasText: "Toystore API" })
@@ -442,7 +508,10 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.goto("/kuadrant/api-products");
       await waitForKuadrantPageReady(page);
 
-      // Toystore API must exist for this test (owned by owner1)
+      // Toystore API must exist for this test (owned by owner1). the products
+      // table pages at 20, so narrow to it first rather than hoping it landed
+      // on the visible page.
+      await narrowProductsTable(page, "Toystore API");
       const toystoreRow = page
         .locator("tr")
         .filter({ hasText: "Toystore API" })
@@ -470,7 +539,9 @@ test.describe("Kuadrant Permissions Matrix", () => {
       await page.goto("/kuadrant/api-products");
       await waitForKuadrantPageReady(page);
 
-      // Toystore API must exist for this test
+      // Toystore API must exist for this test. narrowed first: the products
+      // table pages at 20 and the environment grows products over time.
+      await narrowProductsTable(page, "Toystore API");
       const toystoreRow = page
         .locator("tr")
         .filter({ hasText: "Toystore API" })
@@ -492,32 +563,79 @@ test.describe("Kuadrant Permissions Matrix", () => {
 
     test("admin CAN approve requests for any owner's APIs", async ({
       page,
+      browser,
     }) => {
+      // this test used to pass with nothing to approve. seed a request against
+      // an api the admin does not own, so the approval is exercised end to end
+      // and specifically across an ownership boundary.
+      await seedPendingApiKeyRequest(
+        browser,
+        `admin approves ${generateTestId()}`,
+        owner2Api,
+      );
+
       const common = new Common(page);
       await common.dexQuickLogin("admin@kuadrant.local");
       await page.goto("/kuadrant/api-key-approval");
+      await waitForApiKeysPageReady(page);
 
-      const heading = page
-        .locator("h1, h2")
-        .filter({ hasText: /api key approval/i });
+      // the queue pages at 20 rows and requests accumulate across runs, so a
+      // freshly seeded one can land off the visible page. narrow with the
+      // table's own search first, then identify by count rather than by a
+      // single row: approving one should remove exactly one from the queue.
+      const search = page.getByRole("textbox", { name: "Search" });
+      await search.fill(owner2Api);
+
+      const pendingRows = page
+        .locator("tbody tr")
+        .filter({ hasText: owner2Api })
+        .filter({ has: page.getByRole("button", { name: /^approve$/i }) });
+
       await expect(
-        heading.first(),
-        "Admin should see API Key Approval page",
-      ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+        pendingRows.first(),
+        "the seeded request should be waiting for the admin",
+      ).toBeVisible({ timeout: TIMEOUTS.VERY_SLOW });
+      const before = await pendingRows.count();
 
-      // if there are pending requests, admin should see approve button and it should be enabled
-      const approveButton = page
-        .getByRole("button", { name: /approve/i })
-        .first();
-      const buttonVisible = await approveButton.isVisible().catch(() => false);
+      const approveButton = pendingRows
+        .first()
+        .getByRole("button", { name: /^approve$/i });
+      await expect(
+        approveButton,
+        "Admin approve button should be enabled",
+      ).toBeEnabled({ timeout: TIMEOUTS.DEFAULT });
+      await approveButton.click();
 
-      if (buttonVisible) {
-        await expect(
-          approveButton,
-          "Admin approve button should be enabled",
-        ).toBeEnabled();
-      }
-      // note: test passes if no pending requests (nothing to approve)
+      // approving is confirmed in a modal, and while it is open the table
+      // behind it is out of the a11y tree - so the row assertions below only
+      // mean anything once it has closed.
+      const confirmDialog = page.getByRole("dialog");
+      await expect(
+        confirmDialog,
+        "approving should ask for confirmation",
+      ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
+      await confirmDialog.getByRole("button", { name: /^approve$/i }).click();
+      await expect(
+        confirmDialog,
+        "the confirmation should close once the approval is accepted",
+      ).toBeHidden({ timeout: TIMEOUTS.VERY_SLOW });
+
+      // approving takes that request out of the pending queue. the search is
+      // re-applied on each poll because the table clears it when it refetches,
+      // which would otherwise page the remaining rows back out of sight.
+      await expect
+        .poll(
+          async () => {
+            await search.fill(owner2Api);
+            return pendingRows.count();
+          },
+          {
+            timeout: TIMEOUTS.VERY_SLOW,
+            message:
+              "approving should remove exactly one request from the pending queue",
+          },
+        )
+        .toBe(before - 1);
     });
   });
 

--- a/e2e-tests/playwright/e2e/kuadrant-plugin.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-plugin.spec.ts
@@ -1,6 +1,11 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures/test";
 import { Common } from "../utils/common";
-import { waitForKuadrantPageReady, TIMEOUTS } from "../utils/kuadrant-helpers";
+import {
+  waitForKuadrantPageReady,
+  requestApiKey,
+  generateTestId,
+  TIMEOUTS,
+} from "../utils/kuadrant-helpers";
 
 test.describe("Kuadrant Plugin", () => {
   let common: Common;
@@ -14,7 +19,7 @@ test.describe("Kuadrant Plugin", () => {
 
   test.beforeEach(async ({ page }) => {
     common = new Common(page);
-    await common.loginAsGuest();
+    await common.dexQuickLogin("admin@kuadrant.local");
   });
 
   test("should display Kuadrant menu section in sidebar", async ({ page }) => {
@@ -121,63 +126,51 @@ test.describe("Kuadrant Plugin", () => {
   });
 
   test("should navigate to API Key detail page", async ({ page }) => {
-    await page.goto("/kuadrant/my-api-keys");
+    // seed a key of our own rather than depending on the environment having
+    // one: with nothing to click, this test used to pass without navigating
+    // anywhere.
+    await requestApiKey(page, `detail navigation ${generateTestId()}`);
 
-    // wait for page to load
-    const heading = page.locator("h1, h2").filter({ hasText: /my api keys/i });
-    await expect(heading.first()).toBeVisible({ timeout: TIMEOUTS.SLOW });
-
-    // look for view details button (eye icon)
     const viewDetailsButton = page
       .getByRole("button", { name: /view details/i })
       .first();
-    const buttonVisible = await viewDetailsButton
-      .isVisible()
-      .catch(() => false);
+    await expect(
+      viewDetailsButton,
+      "the key just requested should offer a view details button",
+    ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+    await viewDetailsButton.click();
 
-    if (buttonVisible) {
-      await viewDetailsButton.click();
+    // should navigate to detail page
+    await page.waitForURL(/\/kuadrant\/api-keys\/[^/]+\/[^/]+/);
 
-      // should navigate to detail page
-      await page.waitForURL(/\/kuadrant\/api-keys\/[^/]+\/[^/]+/);
-
-      // verify detail page content
-      const breadcrumb = page.getByText("API keys").first();
-      await expect(breadcrumb).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
-    }
-    // test passes if no API keys exist (nothing to view)
+    // verify detail page content
+    const breadcrumb = page.getByText("API keys").first();
+    await expect(breadcrumb).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
   });
 
   test("should display API Key detail page with correct sections", async ({
     page,
   }) => {
-    // navigate directly to a known API key detail page
-    await page.goto("/kuadrant/my-api-keys");
+    await requestApiKey(page, `detail sections ${generateTestId()}`);
 
-    const heading = page.locator("h1, h2").filter({ hasText: /my api keys/i });
-    await expect(heading.first()).toBeVisible({ timeout: TIMEOUTS.SLOW });
-
-    // find first row in table and click view details
     const viewDetailsButton = page
       .getByRole("button", { name: /view details/i })
       .first();
-    const buttonVisible = await viewDetailsButton
-      .isVisible()
-      .catch(() => false);
+    await expect(
+      viewDetailsButton,
+      "the key just requested should offer a view details button",
+    ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+    await viewDetailsButton.click();
+    await page.waitForURL(/\/kuadrant\/api-keys\/[^/]+\/[^/]+/);
 
-    if (buttonVisible) {
-      await viewDetailsButton.click();
-      await page.waitForURL(/\/kuadrant\/api-keys\/[^/]+\/[^/]+/);
+    // verify detail page sections
+    const detailsCard = page.getByText("API Key Details");
+    await expect(detailsCard.first()).toBeVisible({
+      timeout: TIMEOUTS.DEFAULT,
+    });
 
-      // verify detail page sections
-      const detailsCard = page.getByText("API Key Details");
-      await expect(detailsCard.first()).toBeVisible({
-        timeout: TIMEOUTS.DEFAULT,
-      });
-
-      // verify View API button exists
-      const viewApiButton = page.getByTestId("view-api-button");
-      await expect(viewApiButton).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
-    }
+    // verify View API button exists
+    const viewApiButton = page.getByTestId("view-api-button");
+    await expect(viewApiButton).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
   });
 });

--- a/e2e-tests/playwright/e2e/kuadrant-request-access.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-request-access.spec.ts
@@ -1,6 +1,16 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures/test";
 import { Common } from "../utils/common";
-import { TIMEOUTS, waitForApiKeysPageReady } from "../utils/kuadrant-helpers";
+import {
+  TIMEOUTS,
+  apiKeyTableTotal,
+  waitForApiKeysPageReady,
+  selectFirstOption,
+  openSelect,
+} from "../utils/kuadrant-helpers";
+
+// a demo APIProduct seeded by setup-cluster.sh. named so a test can narrow the
+// table to it rather than counting every row on a paginated page.
+const targetApi = "owner1-payment-api";
 
 /**
  * E2E tests for SimpleRequestAccessDialog
@@ -73,8 +83,9 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
       timeout: TIMEOUTS.DEFAULT,
     });
 
-    // click to open dropdown
-    await apiSelect.click();
+    // click to open dropdown (retried: the menu can be dismissed by the
+    // re-render as the products fetch settles)
+    await openSelect(page, dialog, "api-select");
 
     // verify dropdown shows published APIs (like toystore-api)
     const listbox = page.getByRole("listbox");
@@ -106,8 +117,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
     // select an API (toystore-api should have plans)
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
+    await openSelect(page, dialog, "api-select");
 
     const listbox = page.getByRole("listbox");
     const toystoreOption = listbox
@@ -130,7 +140,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     ).toBeEnabled({ timeout: TIMEOUTS.DEFAULT });
 
     // click tiers dropdown
-    await tierSelect.click();
+    await openSelect(page, dialog, "tier-select");
 
     // verify tiers are populated
     const tierListbox = page.getByRole("listbox");
@@ -154,8 +164,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
     // select toystore-api
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
+    await openSelect(page, dialog, "api-select");
     const listbox = page.getByRole("listbox");
     const toystoreOption = listbox
       .getByRole("option", { name: /toystore/i })
@@ -163,8 +172,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await toystoreOption.click();
 
     // open tiers dropdown
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
+    await openSelect(page, dialog, "tier-select");
 
     // verify tier options show limits (e.g., "bronze (10 per minute)")
     const tierListbox = page.getByRole("listbox");
@@ -201,11 +209,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     ).toBeDisabled({ timeout: TIMEOUTS.DEFAULT });
 
     // select API
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    const apiListbox = page.getByRole("listbox");
-    const apiOption = apiListbox.getByRole("option").first();
-    await apiOption.click();
+    await selectFirstOption(page, dialog, "api-select");
 
     // submit should still be disabled (no tier selected)
     await expect(
@@ -214,11 +218,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     ).toBeDisabled({ timeout: TIMEOUTS.DEFAULT });
 
     // select tier
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    const tierListbox = page.getByRole("listbox");
-    const tierOption = tierListbox.getByRole("option").first();
-    await tierOption.click();
+    await selectFirstOption(page, dialog, "tier-select");
 
     // submit should now be enabled
     await expect(
@@ -269,18 +269,10 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
     // select API
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    const apiOption = listbox.getByRole("option").first();
-    await apiOption.click();
+    await selectFirstOption(page, dialog, "api-select");
 
     // select tier
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    const tierOption = listbox.getByRole("option").first();
-    await tierOption.click();
+    await selectFirstOption(page, dialog, "tier-select");
 
     // fill use case
     const useCaseField = dialog.getByTestId("usecase-input");
@@ -314,15 +306,9 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
     // select API and tier
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await selectFirstOption(page, dialog, "api-select");
 
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await selectFirstOption(page, dialog, "tier-select");
 
     // intercept the request to slow it down
     await page.route("**/api/kuadrant/requests", async (route) => {
@@ -359,10 +345,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
     // select API
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    const listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await selectFirstOption(page, dialog, "api-select");
 
     // fill use case
     const useCaseField = dialog.getByTestId("usecase-input");
@@ -409,10 +392,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
     // verify Tiers field helper text appears after selecting API
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    const listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await selectFirstOption(page, dialog, "api-select");
 
     const tierHelperText = dialog.getByText(
       /select an api to view available tiers/i,
@@ -423,106 +403,104 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
   });
 
-  test("should display error message when request fails", async ({ page }) => {
-    const common = new Common(page);
-    await common.dexQuickLogin("consumer1@kuadrant.local");
-    await page.goto("/kuadrant/my-api-keys");
-    await waitForApiKeysPageReady(page);
+  // these two stub a 500 to check the ui surfaces it, so the guards in
+  // fixtures/test.ts would otherwise fail them on their own fixture.
+  test.describe("simulated backend failures", () => {
+    test.use({ allowExpectedErrors: true });
 
-    const requestButton = page.getByTestId("request-access-button");
-    await requestButton.click();
+    test("should display error message when request fails", async ({
+      page,
+    }) => {
+      const common = new Common(page);
+      await common.dexQuickLogin("consumer1@kuadrant.local");
+      await page.goto("/kuadrant/my-api-keys");
+      await waitForApiKeysPageReady(page);
 
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
+      const requestButton = page.getByTestId("request-access-button");
+      await requestButton.click();
 
-    // intercept the request to simulate a server error
-    await page.route("**/api/kuadrant/requests", async (route) => {
-      await route.fulfill({
-        status: 500,
-        contentType: "application/json",
-        body: JSON.stringify({
-          error: "Server error: Failed to create API key request",
-        }),
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
+
+      // intercept the request to simulate a server error
+      await page.route("**/api/kuadrant/requests", async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error: "Server error: Failed to create API key request",
+          }),
+        });
       });
+
+      // select API and tier
+      await selectFirstOption(page, dialog, "api-select");
+
+      await selectFirstOption(page, dialog, "tier-select");
+
+      // submit
+      const submitButton = dialog.getByTestId("submit-button");
+      await submitButton.click();
+
+      // wait a moment for the error to be processed
+      await page.waitForTimeout(1000);
+
+      // verify error message is displayed (permanent alert)
+      const errorAlert = page.getByText(/failed to request api key/i);
+      await expect(errorAlert, "Error message should be displayed").toBeVisible(
+        {
+          timeout: TIMEOUTS.DEFAULT,
+        },
+      );
     });
 
-    // select API and tier
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    test("should display user-friendly error for email validation failure", async ({
+      page,
+    }) => {
+      const common = new Common(page);
+      await common.dexQuickLogin("consumer1@kuadrant.local");
+      await page.goto("/kuadrant/my-api-keys");
+      await waitForApiKeysPageReady(page);
 
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+      const requestButton = page.getByTestId("request-access-button");
+      await requestButton.click();
 
-    // submit
-    const submitButton = dialog.getByTestId("submit-button");
-    await submitButton.click();
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
-    // wait a moment for the error to be processed
-    await page.waitForTimeout(1000);
-
-    // verify error message is displayed (permanent alert)
-    const errorAlert = page.getByText(/failed to request api key/i);
-    await expect(errorAlert, "Error message should be displayed").toBeVisible({
-      timeout: TIMEOUTS.DEFAULT,
-    });
-  });
-
-  test("should display user-friendly error for email validation failure", async ({
-    page,
-  }) => {
-    const common = new Common(page);
-    await common.dexQuickLogin("consumer1@kuadrant.local");
-    await page.goto("/kuadrant/my-api-keys");
-    await waitForApiKeysPageReady(page);
-
-    const requestButton = page.getByTestId("request-access-button");
-    await requestButton.click();
-
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
-
-    // intercept request to simulate email validation error
-    await page.route("**/api/kuadrant/requests", async (route) => {
-      await route.fulfill({
-        status: 500,
-        contentType: "application/json",
-        body: JSON.stringify({
-          error:
-            'failed to create apikeys: APIKey.devportal.kuadrant.io "test-key" is invalid: spec.requestedBy.email: Invalid value: "admin": spec.requestedBy.email in body should match \'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$\'',
-        }),
+      // intercept request to simulate email validation error
+      await page.route("**/api/kuadrant/requests", async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error:
+              'failed to create apikeys: APIKey.devportal.kuadrant.io "test-key" is invalid: spec.requestedBy.email: Invalid value: "admin": spec.requestedBy.email in body should match \'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$\'',
+          }),
+        });
       });
+
+      // select API and tier
+      await selectFirstOption(page, dialog, "api-select");
+
+      await selectFirstOption(page, dialog, "tier-select");
+
+      // submit
+      const submitButton = dialog.getByTestId("submit-button");
+      await submitButton.click();
+
+      // wait for error processing
+      await page.waitForTimeout(1000);
+
+      // verify user-friendly error message for email validation
+      const emailErrorAlert = page.getByText(
+        /invalid email format.*contact your administrator/i,
+      );
+      await expect(
+        emailErrorAlert,
+        "User-friendly email validation error should be displayed",
+      ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
     });
-
-    // select API and tier
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
-
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
-
-    // submit
-    const submitButton = dialog.getByTestId("submit-button");
-    await submitButton.click();
-
-    // wait for error processing
-    await page.waitForTimeout(1000);
-
-    // verify user-friendly error message for email validation
-    const emailErrorAlert = page.getByText(
-      /invalid email format.*contact your administrator/i,
-    );
-    await expect(
-      emailErrorAlert,
-      "User-friendly email validation error should be displayed",
-    ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
   });
 
   test("should refresh My API Keys table after successful request", async ({
@@ -533,9 +511,19 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await page.goto("/kuadrant/my-api-keys");
     await waitForApiKeysPageReady(page);
 
-    // count initial number of rows
-    const initialRows = page.locator("table tbody tr");
-    const initialCount = await initialRows.count();
+    // the total, not the visible rows: the table pages at 20, so a bare count
+    // stops growing once the first page is full and this test would then never
+    // see its own request arrive. wait for the body to render before taking the
+    // baseline - reading it mid-load returns 0 and the comparison is then
+    // against a number that was never true.
+    await expect(
+      page
+        .locator("table tbody tr")
+        .first()
+        .or(page.getByText(/no api keys found/i)),
+      "the keys table should finish loading before the baseline is taken",
+    ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+    const initialCount = await apiKeyTableTotal(page);
 
     const requestButton = page.getByTestId("request-access-button");
     await requestButton.click();
@@ -544,15 +532,9 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
     // select API and tier
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await selectFirstOption(page, dialog, "api-select", targetApi);
 
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await selectFirstOption(page, dialog, "tier-select");
 
     // submit
     const submitButton = dialog.getByTestId("submit-button");
@@ -561,15 +543,11 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     // wait for dialog to close
     await expect(dialog).not.toBeVisible({ timeout: TIMEOUTS.SLOW });
 
-    // wait a moment for table to refresh
-    await page.waitForTimeout(2000);
-
-    // verify table has been updated (should have one more row)
-    const updatedRows = page.locator("table tbody tr");
-    const updatedCount = await updatedRows.count();
-    expect(
-      updatedCount,
-      "Table should have one more row after successful request",
-    ).toBeGreaterThan(initialCount);
+    await expect
+      .poll(() => apiKeyTableTotal(page), {
+        timeout: TIMEOUTS.SLOW,
+        message: "Table should have one more row after successful request",
+      })
+      .toBe(initialCount + 1);
   });
 });

--- a/e2e-tests/playwright/e2e/kuadrant-skeleton-loaders.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-skeleton-loaders.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures/test";
 import { Common } from "../utils/common";
 import { TIMEOUTS } from "../utils/kuadrant-helpers";
 
@@ -14,7 +14,7 @@ test.describe("Kuadrant Skeleton Loaders", () => {
 
   test.beforeEach(async ({ page }) => {
     common = new Common(page);
-    await common.loginAsGuest();
+    await common.dexQuickLogin("admin@kuadrant.local");
   });
 
   test("should show skeleton loaders on My API Keys page while loading", async ({
@@ -109,23 +109,25 @@ test.describe("Kuadrant Skeleton Loaders", () => {
       await expect(catalogHeading.first()).toBeVisible();
     }).toPass({ timeout: TIMEOUTS.SLOW });
 
-    // Try to find and click on an API entity (toystore or any other)
+    // the catalog is seeded with APIProducts by setup-cluster.sh, so an api
+    // entity is expected rather than optional - the old `if (count > 0)` meant
+    // an empty catalog passed this test without ever opening an entity page.
     const apiLink = page.locator('a[href*="/catalog/"][href*="/api/"]').first();
-    const hasApiLink = await apiLink.count();
+    await expect(
+      apiLink,
+      "catalog should list at least one api entity to open",
+    ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+    await apiLink.click();
 
-    if (hasApiLink > 0) {
-      await apiLink.click();
+    // Eventually page should be fully loaded without skeletons
+    await expect(async () => {
+      const visibleSkeletons = page.locator(".MuiSkeleton-root:visible");
+      await expect(visibleSkeletons).toHaveCount(0);
+    }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
 
-      // Eventually page should be fully loaded without skeletons
-      await expect(async () => {
-        const visibleSkeletons = page.locator(".MuiSkeleton-root:visible");
-        await expect(visibleSkeletons).toHaveCount(0);
-      }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
-
-      // Verify the page loaded (may or may not have the Kuadrant card depending on the API)
-      const content = page.locator("main");
-      await expect(content).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
-    }
+    // Verify the page loaded (may or may not have the Kuadrant card depending on the API)
+    const content = page.locator("main");
+    await expect(content).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
   });
 
   test("should not show old Progress spinners anywhere", async ({ page }) => {
@@ -183,27 +185,26 @@ test.describe("Kuadrant Skeleton Loaders", () => {
       await expect(heading).toBeVisible();
     }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
 
-    // Try to find a link to an API Product detail page
+    // as above: the demo APIProducts are seeded, so a product link is expected.
     const productLink = page
       .locator('a[href*="/kuadrant/api-products/"]')
       .first();
-    const hasProductLink = await productLink.count();
+    await expect(
+      productLink,
+      "api products list should link to at least one product",
+    ).toBeVisible({ timeout: TIMEOUTS.SLOW });
+    await productLink.click();
 
-    if (hasProductLink > 0) {
-      // Click to navigate to detail page
-      await productLink.click();
+    // Wait for full load
+    await expect(async () => {
+      const visibleSkeletons = page.locator(".MuiSkeleton-root:visible");
+      await expect(visibleSkeletons).toHaveCount(0);
+    }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
 
-      // Wait for full load
-      await expect(async () => {
-        const visibleSkeletons = page.locator(".MuiSkeleton-root:visible");
-        await expect(visibleSkeletons).toHaveCount(0);
-      }).toPass({ timeout: TIMEOUTS.VERY_SLOW });
-
-      // Verify page loaded with real content (check for header or main content)
-      await expect(async () => {
-        const pageHeader = page.locator("header, h1").first();
-        await expect(pageHeader).toBeVisible();
-      }).toPass({ timeout: TIMEOUTS.DEFAULT });
-    }
+    // Verify page loaded with real content (check for header or main content)
+    await expect(async () => {
+      const pageHeader = page.locator("header, h1").first();
+      await expect(pageHeader).toBeVisible();
+    }).toPass({ timeout: TIMEOUTS.DEFAULT });
   });
 });

--- a/e2e-tests/playwright/e2e/smoke-test.spec.ts
+++ b/e2e-tests/playwright/e2e/smoke-test.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures/test";
 import { Common } from "../utils/common";
 test.describe("Smoke test", () => {
   let common: Common;
@@ -12,7 +12,7 @@ test.describe("Smoke test", () => {
 
   test.beforeEach(async ({ page }) => {
     common = new Common(page);
-    await common.loginAsGuest();
+    await common.dexQuickLogin("admin@kuadrant.local");
   });
 
   test("Verify the Homepage renders", async ({ page }) => {

--- a/e2e-tests/playwright/fixtures/test.ts
+++ b/e2e-tests/playwright/fixtures/test.ts
@@ -1,0 +1,131 @@
+import { test as base, expect, Page } from "@playwright/test";
+
+/**
+ * Guards every test against failures that would otherwise pass silently.
+ *
+ * A spec that asserts on rendered text will happily go green while the backend
+ * answers 500 and the UI shows an empty table, or while an uncaught exception
+ * takes out a component the assertion never looks at. These three listeners
+ * turn those into failures.
+ *
+ * Imported in place of `@playwright/test`, so no spec has to opt in.
+ */
+
+// console.error text we do not treat as a failure. the guard exists to catch
+// OUR regressions (e.g. a failed fetch our code logs but never throws), so keep
+// this list to noise we can prove is third-party: an entry that could also
+// match our own output would blind the guard. widen only with a stock source.
+const consoleNoise = [
+  // browser-generated line for a request that already failed. the network
+  // status is the useful signal and the 5xx guard below already carries it;
+  // this repeats it without the status or path, and fires for expected non-2xx
+  // too (the pre-sign-in auth probe 401s by design).
+  /^Failed to load resource:/,
+
+  // the rest are react dev-mode warnings and mui advisories from third-party
+  // components the rhdh shell renders. yarn dev runs react in development so
+  // they fire; the production dynamic build strips them. rhdh pins these deps,
+  // none of it is our code, and each pattern matches the whole warning class
+  // (any offending component), not just the instances the homepage happened to
+  // surface.
+
+  // react-beautiful-dnd (via @backstage-community/plugin-rbac) calls the
+  // deprecated findDOMNode.
+  /findDOMNode is deprecated/,
+
+  // material-table (MTableHeader, MTablePagination) and Connect(Droppable) from
+  // react-beautiful-dnd set defaultProps on function/memo components.
+  /Support for defaultProps will be removed/,
+
+  // mui advisory about MuiBottomNavigationAction css specificity.
+  /MuiBottomNavigationAction/,
+
+  // stock backstage nests a Typography h2 inside an h5 in its page header.
+  /validateDOMNesting/,
+];
+
+// 5xx from these is the backend admitting it broke. anything else - 4xx, or a
+// 5xx from a route we do not own - is left to the test's own assertions.
+const kuadrantApi = /^\/api\/kuadrant\//;
+
+function watchForFailures(page: Page, failures: string[]) {
+  page.on("response", (response) => {
+    const { pathname } = new URL(response.url());
+    if (kuadrantApi.test(pathname) && response.status() >= 500) {
+      failures.push(
+        `${response.status()} from ${response.request().method()} ${pathname}`,
+      );
+    }
+  });
+
+  page.on("requestfailed", (request) => {
+    // a 5xx at least got answered; a requestfailed is the request never
+    // completing - dns, a reset, a refused connection - which the response
+    // guard above never sees. same url filter, so it stays about our backend.
+    const { pathname } = new URL(request.url());
+    if (!kuadrantApi.test(pathname)) return;
+
+    // the browser aborts in-flight requests when the spa navigates away mid
+    // fetch; that is expected churn, not a transport fault.
+    const errorText = request.failure()?.errorText ?? "";
+    if (errorText === "net::ERR_ABORTED") return;
+
+    failures.push(
+      `request failed: ${request.method()} ${pathname} (${errorText})`,
+    );
+  });
+
+  page.on("pageerror", (error) => {
+    failures.push(`uncaught exception: ${error.message}`);
+  });
+
+  page.on("console", (message) => {
+    if (message.type() !== "error") return;
+    const text = message.text();
+    if (consoleNoise.some((pattern) => pattern.test(text))) return;
+    failures.push(`console error: ${text}`);
+  });
+}
+
+const TEST = base.extend<{
+  /**
+   * Opt a test out of the guards below.
+   *
+   * Only for tests whose subject IS the error path - the ones that stub a 500
+   * with `page.route(...).fulfill(...)` to check the UI reports it. There the
+   * error is the fixture of the test, not a fault, and the app logging it is
+   * the behaviour under test.
+   *
+   * Set per describe block: `test.use({ allowExpectedErrors: true })`. Do not
+   * reach for it to quieten a failure you have not explained.
+   */
+  allowExpectedErrors: boolean;
+  failOnRuntimeErrors: void;
+}>({
+  allowExpectedErrors: [false, { option: true }],
+
+  failOnRuntimeErrors: [
+    async ({ page, allowExpectedErrors }, use) => {
+      if (allowExpectedErrors) {
+        await use();
+        return;
+      }
+
+      const failures: string[] = [];
+      watchForFailures(page, failures);
+
+      await use();
+
+      expect
+        .soft(
+          failures,
+          "backend 5xx, uncaught exceptions and console errors seen during this test",
+        )
+        .toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+export { TEST as test, expect };
+export type { Page };

--- a/e2e-tests/playwright/utils/kuadrant-helpers.ts
+++ b/e2e-tests/playwright/utils/kuadrant-helpers.ts
@@ -1,4 +1,4 @@
-import { Page, Locator, expect } from "@playwright/test";
+import { Page, Locator, Browser, expect } from "@playwright/test";
 import { Common } from "./common";
 
 // timeout constants for consistent test behaviour
@@ -15,6 +15,9 @@ export function generateTestId(): string {
 }
 
 export interface TestAPIProduct {
+  // the unique part, shared by name and displayName. use it to find the product
+  // in a table without having to know which of the two that table renders.
+  id: string;
   name: string;
   displayName: string;
   namespace: string;
@@ -24,6 +27,7 @@ export interface TestAPIProduct {
 export function createTestAPIProductData(owner: string): TestAPIProduct {
   const id = generateTestId();
   return {
+    id,
     name: `e2e-test-api-${id}`,
     displayName: `E2E Test API ${id}`,
     namespace: "default",
@@ -160,6 +164,162 @@ export async function waitForApiKeysPageReady(
     const heading = page.locator("h1").filter({ hasText: headingPattern });
     await expect(heading).toBeVisible();
   }).toPass({ timeout: TIMEOUTS.VERY_SLOW, intervals: [500, 1000, 2000] });
+}
+
+/**
+ * How many rows the API keys table holds in total, not just on screen.
+ *
+ * Rows for the same API product are indistinguishable in the DOM, and the table
+ * pages at 20 - so counting visible rows proves nothing once the first page is
+ * full: adding one pushes another off, removing one pulls the next up. The
+ * pagination footer carries the real total, so read that where it is rendered
+ * (material-table only pages past 10 rows) and fall back to counting otherwise.
+ *
+ * @param page - The Playwright Page object
+ */
+export async function apiKeyTableTotal(page: Page): Promise<number> {
+  const label = page.getByText(/\d+-\d+ of \d+/);
+  if (await label.count()) {
+    const match = (await label.first().innerText()).match(/of (\d+)/);
+    if (match) return Number(match[1]);
+  }
+  return page.locator("table tbody tr").count();
+}
+
+/**
+ * Open a MUI Select and wait until its options are on screen.
+ *
+ * Two things make a bare `.click()` unreliable here. The select is disabled
+ * while its options load, and a click on a disabled MUI Select is silently
+ * swallowed - no menu opens, and the later wait for an option times out
+ * complaining about the listbox rather than the real cause. Even once enabled,
+ * a re-render as the fetch settles can dismiss a menu that did open. So: wait
+ * for enabled, then retry the open until options are actually showing.
+ *
+ * Use this wherever a test wants to assert on the options itself; use
+ * selectFirstOption when it just needs a value chosen.
+ *
+ * @param page - The Playwright Page object
+ * @param container - The Locator the select lives in (usually the dialog)
+ * @param testId - data-testid of the select, e.g. "api-select"
+ */
+export async function openSelect(
+  page: Page,
+  container: Locator,
+  testId: string,
+): Promise<void> {
+  const select = container.getByTestId(testId);
+  await expect(
+    select,
+    `${testId} should become enabled once its options have loaded`,
+  ).toBeEnabled({ timeout: TIMEOUTS.SLOW });
+
+  await expect(async () => {
+    await select.click();
+    await expect(
+      page.getByRole("listbox").getByRole("option").first(),
+    ).toBeVisible({ timeout: TIMEOUTS.QUICK });
+  }).toPass({ timeout: TIMEOUTS.SLOW, intervals: [250, 500, 1000] });
+}
+
+/**
+ * Open one of the Request Access dialog's selects and choose an option.
+ *
+ * @param page - The Playwright Page object
+ * @param dialog - The dialog Locator the select lives in
+ * @param testId - data-testid of the select, e.g. "api-select"
+ * @param optionName - Exact option to pick; the first option if omitted
+ */
+export async function selectFirstOption(
+  page: Page,
+  dialog: Locator,
+  testId: string,
+  optionName?: string,
+): Promise<void> {
+  await openSelect(page, dialog, testId);
+
+  const listbox = page.getByRole("listbox");
+  const option = optionName
+    ? listbox.getByRole("option", { name: optionName, exact: true })
+    : listbox.getByRole("option").first();
+  await expect(
+    option,
+    `${testId} should offer ${optionName ?? "at least one option"}`,
+  ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
+  await option.click();
+}
+
+/**
+ * Request an API key through the UI, so a test that needs one to exist can
+ * create it rather than skip itself when the environment happens to be empty.
+ *
+ * Picks the first API and the first tier offered. Returns once the dialog has
+ * closed, which the dialog only does on a successful submission.
+ *
+ * @param page - The Playwright Page object
+ * @param useCase - Use-case text, worth making unique per test so the resulting
+ *   row can be identified.
+ */
+export async function requestApiKey(
+  page: Page,
+  useCase: string,
+  apiProductName?: string,
+): Promise<void> {
+  await page.goto("/kuadrant/my-api-keys");
+  await waitForApiKeysPageReady(page);
+
+  await page.getByTestId("request-access-button").click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog, "Request Access dialog should open").toBeVisible({
+    timeout: TIMEOUTS.DEFAULT,
+  });
+
+  await selectFirstOption(page, dialog, "api-select", apiProductName);
+  await selectFirstOption(page, dialog, "tier-select");
+
+  await dialog.getByTestId("usecase-input").fill(useCase);
+  await dialog.getByTestId("submit-button").click();
+
+  await expect(
+    dialog,
+    "Request Access dialog should close once the request is accepted",
+  ).not.toBeVisible({ timeout: TIMEOUTS.SLOW });
+}
+
+/**
+ * Create a pending API key request as a consumer, in a browser context of its
+ * own, so an approver test has something to approve.
+ *
+ * A separate context avoids signing out and back in on the test's own page,
+ * which would throw away the approver session the test is there to exercise.
+ *
+ * The API product is named rather than "whichever is first", because an
+ * approval queue only shows requests for APIs the approver owns - so a test
+ * about owner1's queue has to seed against an API owner1 owns.
+ *
+ * @param browser - The Playwright Browser, from the test's `browser` fixture
+ * @param useCase - Use-case text, recorded on the request
+ * @param apiProductName - Name of the APIProduct to request access to
+ */
+export async function seedPendingApiKeyRequest(
+  browser: Browser,
+  useCase: string,
+  apiProductName: string,
+): Promise<void> {
+  // a manually created context inherits nothing from the config's `use` block,
+  // so mirror the baseURL (dexQuickLogin starts with a relative goto) and the
+  // https override the rest of the suite runs with.
+  const context = await browser.newContext({
+    baseURL: process.env.BASE_URL || "http://localhost:3000",
+    ignoreHTTPSErrors: true,
+  });
+  try {
+    const page = await context.newPage();
+    await new Common(page).dexQuickLogin("consumer1@kuadrant.local");
+    await requestApiKey(page, useCase, apiProductName);
+  } finally {
+    await context.close();
+  }
 }
 
 /**

--- a/e2e-tests/rhdh/Dockerfile
+++ b/e2e-tests/rhdh/Dockerfile
@@ -1,0 +1,18 @@
+# derived rhdh image for the dynamic-plugin e2e job.
+# bakes the locally-built kuadrant dynamic plugins into a stock rhdh image so ci
+# validates the current branch's export-dynamic output without publishing to npm.
+#
+# build context is the repo root:
+#   docker build -f e2e-tests/rhdh/Dockerfile -t <tag> .
+# run yarn build + export-dynamic in both plugins first so the dist-dynamic dirs exist.
+
+ARG RHDH_BASE_IMAGE=quay.io/rhdh-community/rhdh:1.10
+FROM ${RHDH_BASE_IMAGE}
+
+# setup-rhdh.sh references these as ./dynamic-plugins/dist/<dir>, relative to
+# /opt/app-root/src. Group 0 + uid 1001 keeps them readable under OpenShift's
+# arbitrary-uid semantics.
+COPY --chown=1001:0 plugins/kuadrant/dist-dynamic \
+  /opt/app-root/src/dynamic-plugins/dist/kuadrant-kuadrant-backstage-plugin-frontend
+COPY --chown=1001:0 plugins/kuadrant-backend/dist-dynamic \
+  /opt/app-root/src/dynamic-plugins/dist/kuadrant-kuadrant-backstage-plugin-backend-dynamic

--- a/e2e-tests/rhdh/wait-for-catalog.sh
+++ b/e2e-tests/rhdh/wait-for-catalog.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# waits for the kuadrant demo apiproducts to be ingested into the backstage
+# catalog before the dynamic-plugin e2e specs run.
+#
+# the apiproduct entity provider syncs on a periodic schedule, so the catalog is
+# empty for a short window after the backend starts. the auth-scheme specs have
+# positive asserts on these entities (e.g. /catalog/default/api/toystore-api);
+# without this gate they race the first sync and flake. the frontend readiness
+# curl on the route does not cover catalog content.
+#
+# entities are given as kind/namespace/name and default to the two the positive
+# specs depend on. guest is a superuser here, so catalog reads need its bearer
+# token.
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://rhdh.localhost:9080}"
+TIMEOUT="${CATALOG_TIMEOUT:-120}"
+
+if [ "$#" -gt 0 ]; then
+  ENTITIES=("$@")
+else
+  ENTITIES=(api/default/toystore-api api/default/gamestore-admin)
+fi
+
+log() { echo ">> $*"; }
+
+get_guest_token() {
+  curl -fsS -X POST "${BASE_URL}/api/auth/guest/refresh" 2>/dev/null |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["backstageIdentity"]["token"])' 2>/dev/null
+}
+
+entity_present() {
+  local token="$1" ref="$2" code
+  code=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer ${token}" \
+    "${BASE_URL}/api/catalog/entities/by-name/${ref}" 2>/dev/null || true)
+  [ "${code}" = "200" ]
+}
+
+dump_catalog_apis() {
+  local token="$1"
+  log "catalog api entities currently present:"
+  curl -sS -H "Authorization: Bearer ${token}" \
+    "${BASE_URL}/api/catalog/entities/by-query?filter=kind%3Dapi&limit=100" 2>/dev/null |
+    python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+    items = d.get("items", d if isinstance(d, list) else [])
+    if not items:
+        print("  (none)")
+    for e in items:
+        m = e.get("metadata", {})
+        ns = m.get("namespace")
+        nm = m.get("name")
+        print(f"  - {ns}/{nm}")
+except Exception as ex:
+    print(f"  (could not parse catalog response: {ex})")' 2>/dev/null ||
+    log "  (catalog query failed)"
+}
+
+log "waiting up to ${TIMEOUT}s for catalog entities: ${ENTITIES[*]}"
+deadline=$(($(date +%s) + TIMEOUT))
+while true; do
+  token="$(get_guest_token || true)"
+  missing=()
+  if [ -n "${token}" ]; then
+    for ref in "${ENTITIES[@]}"; do
+      entity_present "${token}" "${ref}" || missing+=("${ref}")
+    done
+    if [ "${#missing[@]}" -eq 0 ]; then
+      log "all catalog entities present: ${ENTITIES[*]}"
+      exit 0
+    fi
+  else
+    missing=("(no guest token yet)")
+  fi
+
+  if [ "$(date +%s)" -ge "${deadline}" ]; then
+    log "error: timed out after ${TIMEOUT}s waiting for catalog entities"
+    log "still missing: ${missing[*]}"
+    dump_catalog_apis "${token:-}"
+    exit 1
+  fi
+  sleep 3
+done

--- a/kuadrant-dev-setup/Makefile
+++ b/kuadrant-dev-setup/Makefile
@@ -37,7 +37,7 @@ kind-create: $(KIND) $(HELM)
 	@kubectl cluster-info --context kind-$(CLUSTER_NAME)
 	@echo ""
 	@echo "creating rhdh service account and rbac..."
-	@kubectl apply -f rbac/rhdh-rbac.yaml
+	@kubectl apply -f rbac/rhdh-cluster-role.yaml -f rbac/rhdh-rbac.yaml
 	@echo ""
 	@echo "configure kubernetes integration with backstage using rhdh service account..."
 	@./scripts/kube-env-setup.sh

--- a/kuadrant-dev-setup/README.md
+++ b/kuadrant-dev-setup/README.md
@@ -51,7 +51,8 @@ kuadrant-dev-setup/
 ├── demo/                     # demo resources
 │   └── toystore-demo.yaml    # toystore api with policies
 ├── rbac/                     # rbac configs
-│   └── rhdh-rbac.yaml        # rhdh service account permissions
+│   ├── rhdh-cluster-role.yaml # shared RHDH Kubernetes permissions
+│   └── rhdh-rbac.yaml         # kind service account and binding
 └── scripts/                  # helper scripts
     └── kind-cluster.yaml     # kind cluster configuration
 ```

--- a/kuadrant-dev-setup/dex/config.yaml
+++ b/kuadrant-dev-setup/dex/config.yaml
@@ -47,8 +47,11 @@ staticPasswords:
 staticClients:
   - id: backstage
     redirectURIs:
+      # yarn dev (frontend on 3000, backend on 7007)
       - "http://localhost:3000/api/auth/oidc/handler/frame"
       - "http://localhost:7007/api/auth/oidc/handler/frame"
+      # oinc (make dynamic-up), where rhdh is served from a single origin
+      - "http://rhdh.localhost:9080/api/auth/oidc/handler/frame"
     name: "Backstage Local Dev"
     secret: "backstage-dev-secret"
 

--- a/kuadrant-dev-setup/rbac/rhdh-cluster-role.yaml
+++ b/kuadrant-dev-setup/rbac/rhdh-cluster-role.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhdh-kuadrant-reader
+rules:
+  - apiGroups: ["kuadrant.io"]
+    resources: [authpolicies, ratelimitpolicies, dnspolicies, tlspolicies]
+    verbs: [get, list, watch]
+  - apiGroups: ["extensions.kuadrant.io"]
+    resources: [planpolicies]
+    verbs: [get, list, watch]
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: [apiproducts, apikeys]
+    verbs: [get, list, watch, create, delete, patch, update]
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: [apikeys/status]
+    verbs: [get, patch, update]
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: [apikeyrequests]
+    verbs: [get, list, watch]
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: [apikeyapprovals]
+    verbs: [get, list, watch, create, patch, update]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: [gateways, httproutes]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, list, watch, create]
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [get, create, delete]

--- a/kuadrant-dev-setup/rbac/rhdh-rbac.yaml
+++ b/kuadrant-dev-setup/rbac/rhdh-rbac.yaml
@@ -1,52 +1,8 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rhdh
   namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: rhdh-kuadrant-reader
-rules:
-  - apiGroups: ["kuadrant.io"]
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - dnspolicies
-      - tlspolicies
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions.kuadrant.io"]
-    resources:
-      - planpolicies
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["devportal.kuadrant.io"]
-    resources:
-      - apiproducts
-      - apikeys
-    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
-  - apiGroups: ["devportal.kuadrant.io"]
-    resources:
-      - apikeyrequests
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["devportal.kuadrant.io"]
-    resources:
-      - apikeyapprovals
-    verbs: ["get", "list", "watch", "create", "patch", "update"]
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources:
-      - gateways
-      - httproutes
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources:
-      - namespaces
-    verbs: ["get", "list", "watch", "create"]
-  - apiGroups: [""]
-    resources:
-      - secrets
-    verbs: ["get", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/oinc/lib.sh
+++ b/oinc/lib.sh
@@ -3,17 +3,6 @@
 
 log() { echo "==> $*"; }
 
-detect_runtime() {
-  if command -v podman &>/dev/null; then
-    echo "podman"
-  elif command -v docker &>/dev/null; then
-    echo "docker"
-  else
-    echo "error: no container runtime found (need podman or docker)"
-    exit 1
-  fi
-}
-
 check_command() {
   if ! command -v "$1" &>/dev/null; then
     echo "error: '$1' not found. $2"

--- a/oinc/manifests/dex.yaml
+++ b/oinc/manifests/dex.yaml
@@ -1,0 +1,99 @@
+# The issuer must resolve from both the browser and the RHDH pod. On the host,
+# dex.localhost reaches the oinc ingress. In-cluster, the same name resolves to
+# Service dex in Namespace localhost through the Kubernetes DNS search path.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: localhost
+  labels:
+    app: dex
+spec:
+  replicas: 1
+  # Dex uses in-memory storage, so avoid two pods during an update.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dex
+          image: ghcr.io/dexidp/dex:v2.45.1
+          args: ["dex", "serve", "/etc/dex/config.yaml"]
+          ports:
+            - name: http
+              containerPort: 5556
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            - name: web
+              mountPath: /srv/dex/web/templates/password.html
+              subPath: password.html
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 20m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: dex-config
+        - name: web
+          configMap:
+            name: dex-web
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: localhost
+spec:
+  selector:
+    app: dex
+  ports:
+    - name: http
+      port: 9080
+      targetPort: http
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: dex
+  namespace: localhost
+spec:
+  host: dex.localhost
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: dex

--- a/oinc/manifests/rhdh-sa.yaml
+++ b/oinc/manifests/rhdh-sa.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -9,45 +8,6 @@ kind: ServiceAccount
 metadata:
   name: rhdh-kuadrant
   namespace: rhdh
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: rhdh-kuadrant-reader
-rules:
-  - apiGroups: ["kuadrant.io"]
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - dnspolicies
-      - tlspolicies
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions.kuadrant.io"]
-    resources:
-      - planpolicies
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["devportal.kuadrant.io"]
-    resources:
-      - apiproducts
-      - apikeys
-    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
-  - apiGroups: ["devportal.kuadrant.io"]
-    resources:
-      - apikeys/status
-    verbs: ["get", "patch", "update"]
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources:
-      - gateways
-      - httproutes
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources:
-      - namespaces
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources:
-      - secrets
-    verbs: ["get", "list", "watch", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/oinc/setup-cluster.sh
+++ b/oinc/setup-cluster.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# create an oinc cluster with kuadrant, istio, metallb, and a gateway.
-# applies demo resources for local development.
+# create an oinc cluster with kuadrant, istio, metallb, cert-manager and gateway
+# api, then apply the demo resources the catalog e2e and local dev depend on.
+#
+# oinc v0.3.1 addon options do the generic instance creation this script used to
+# hand-roll:
+#   --kuadrant-devportal        enable developerPortal on the Kuadrant CR
+#                               (persist-verified) and wait for its controller
+#   --metallb-address-pool auto create an IPAddressPool + L2Advertisement, range
+#                               derived from the container network
+#   --gateway-api-gateway       create the default kuadrant-ingressgateway and
+#                               wait until it is programmed (needs the metallb
+#                               pool for its address, so the two go together)
+# only the kuadrant demo manifests stay consumer-side; oinc ships none.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -10,70 +21,64 @@ REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # shellcheck source=lib.sh
 source "${SCRIPT_DIR}/lib.sh"
 
-check_command oinc "Install from https://github.com/jasonmadigan/oinc"
+check_command oinc "Install from https://github.com/jasonmadigan/oinc (v0.3.1+)"
 check_command kubectl "Install from https://kubernetes.io/docs/tasks/tools/"
 
-RUNTIME=$(detect_runtime)
+# pin to a soaked ocp release; oinc defaults to the newest, which lags in ci.
+OCP_VERSION="${OCP_VERSION:-4.21}"
+# Pin the version exercised by this path; callers can override it explicitly.
+KUADRANT_VERSION="${KUADRANT_VERSION:-1.5.1}"
 
 # --- cluster + addons ---
 
-log "creating oinc cluster with addons..."
-oinc create --addons kuadrant
+# dump kuadrant state on a failed create so ci logs are diagnosable, not opaque.
+# create now also enables the portal and creates the pool + gateway, so a wedge
+# in any of those surfaces here too.
+dump_kuadrant_diagnostics() {
+  log "oinc create failed - dumping kuadrant diagnostics..."
+  kubectl get kuadrant kuadrant -n kuadrant-system -o yaml 2>&1 || true
+  kubectl get pods -n kuadrant-system -o wide 2>&1 || true
+  kubectl logs deployment/kuadrant-operator-controller-manager -n kuadrant-system \
+    --tail=200 --all-containers 2>&1 || true
+}
 
-log "merging kubeconfig..."
-oinc kubeconfig
-
-# --- MetalLB IP pool ---
-
-log "configuring MetalLB IP pool..."
-DOCKER_SUBNET=$(${RUNTIME} network inspect bridge -f '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || echo "172.18.0.0/16")
-POOL_START=$(echo "${DOCKER_SUBNET}" | sed 's|\.[0-9]*/.*|.200|')
-POOL_END=$(echo "${DOCKER_SUBNET}" | sed 's|\.[0-9]*/.*|.220|')
-
-log "MetalLB pool: ${POOL_START}-${POOL_END}"
-kubectl apply -f - <<EOF
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
-metadata:
-  name: dev-pool
-  namespace: metallb-system
-spec:
-  addresses:
-  - ${POOL_START}-${POOL_END}
----
-apiVersion: metallb.io/v1beta1
-kind: L2Advertisement
-metadata:
-  name: dev-l2
-  namespace: metallb-system
-EOF
-
-# --- Gateway ---
-
-log "creating gateway..."
-kubectl create namespace gateway-system 2>/dev/null || true
-kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: kuadrant-ingressgateway
-  namespace: gateway-system
-spec:
-  gatewayClassName: istio
-  listeners:
-  - name: http
-    port: 80
-    protocol: HTTP
-    allowedRoutes:
-      namespaces:
-        from: All
-EOF
+# errexit is suspended for an `if` condition, so a failed create falls through to
+# the diagnostics dump and an explicit exit instead of dying silently.
+log "creating oinc cluster (ocp ${OCP_VERSION}, kuadrant@${KUADRANT_VERSION}) with developer portal, metallb pool and default gateway..."
+if ! oinc create --version "${OCP_VERSION}" --addons "kuadrant@${KUADRANT_VERSION}" \
+  --kuadrant-devportal \
+  --metallb-address-pool auto \
+  --gateway-api-gateway; then
+  dump_kuadrant_diagnostics
+  exit 1
+fi
 
 # --- demo resources ---
 
 log "applying demo resources..."
+# retry per file: the demo manifests include apikey/planpolicy kinds whose crds
+# can lag apiproducts on a fresh cluster, so a first apply may race crd
+# establishment. bounded retry rides that out, then fails loud with the kubectl
+# error visible - the e2e depends on these apiproducts, and a silent skip only
+# resurfaces later as an opaque catalog-gate timeout.
+apply_demo() {
+  local file="$1" attempt=1 max=5
+  while true; do
+    if kubectl apply -f "${file}"; then
+      return 0
+    fi
+    if [ "${attempt}" -ge "${max}" ]; then
+      log "error: failed to apply ${file} after ${max} attempts"
+      return 1
+    fi
+    log "apply ${file##*/} failed (try ${attempt}/${max}), retrying in 6s..."
+    attempt=$((attempt + 1))
+    sleep 6
+  done
+}
+
 for f in toystore-demo.yaml gamestore-demo.yaml additional-demos.yaml; do
-  kubectl apply -f "${REPO_DIR}/kuadrant-dev-setup/demo/${f}" || log "warning: failed to apply ${f}"
+  apply_demo "${REPO_DIR}/kuadrant-dev-setup/demo/${f}" || exit 1
 done
 
 # --- done ---
@@ -83,7 +88,8 @@ echo "============================================"
 echo " oinc cluster ready"
 echo "============================================"
 echo ""
-echo " Cluster has: Gateway API, cert-manager, MetalLB, Istio, Kuadrant, demo resources"
+echo " Cluster has: Gateway API, cert-manager, MetalLB, Istio, Kuadrant"
+echo " (developer portal, address pool, default gateway), demo resources"
 echo ""
 echo " OpenShift Console:"
 echo "   http://localhost:9000"

--- a/oinc/setup-dex.sh
+++ b/oinc/setup-dex.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+DEX_CONFIG="${REPO_DIR}/kuadrant-dev-setup/dex/config.yaml"
+DEX_PASSWORD_TEMPLATE="${REPO_DIR}/kuadrant-dev-setup/dex/web/templates/password.html"
+DEX_URL="${DEX_URL:-http://dex.localhost:9080}"
+
+check_command kubectl "Install from https://kubernetes.io/docs/tasks/tools/"
+
+for file in "${DEX_CONFIG}" "${DEX_PASSWORD_TEMPLATE}"; do
+  [ -f "${file}" ] || {
+    log "error: ${file} not found"
+    exit 1
+  }
+done
+
+rendered_config=$(mktemp)
+trap 'rm -f "${rendered_config}"' EXIT
+sed -E "s|^issuer:[[:space:]].*|issuer: ${DEX_URL}|" \
+  "${DEX_CONFIG}" >"${rendered_config}"
+
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: localhost
+EOF
+
+existed=false
+kubectl -n localhost get deployment/dex &>/dev/null && existed=true
+
+kubectl create configmap dex-config -n localhost \
+  --from-file=config.yaml="${rendered_config}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl create configmap dex-web -n localhost \
+  --from-file=password.html="${DEX_PASSWORD_TEMPLATE}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f "${SCRIPT_DIR}/manifests/dex.yaml"
+
+if [ "${existed}" = true ]; then
+  kubectl -n localhost rollout restart deployment/dex
+fi
+kubectl -n localhost rollout status deployment/dex --timeout=180s
+log "dex ready at ${DEX_URL}"

--- a/oinc/setup-rhdh.sh
+++ b/oinc/setup-rhdh.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
-# installs and configures RHDH on an existing oinc cluster.
-# expects setup-cluster.sh to have been run first.
+# installs RHDH on an existing oinc cluster with the kuadrant plugins loaded as
+# dynamic plugins. expects setup-cluster.sh to have been run first.
+#
+# the oinc rhdh addon (v0.3.0+) owns the generic plumbing: the rhdh/backstage
+# helm chart, the custom image override, the microshift volume/postgres
+# workarounds, guest auth, and route exposure on the mapped http port. this
+# script composes the kuadrant-specific bits - the dynamic-plugins list and
+# frontend pluginConfig, the k8s cluster locator + sa token, catalog rules and
+# rbac - as a helm values overlay and hands off to `oinc addon install rhdh`.
+#
+# two plugin sources (PLUGIN_SOURCE):
+#   npm    (default) - published @kuadrant packages, fetched by the init
+#          container with integrity hashes. used by local `yarn oinc:rhdh`.
+#   baked  - locally-built dist-dynamic dirs baked into a derived rhdh image
+#          (RHDH_IMAGE_REPOSITORY:RHDH_IMAGE_TAG), referenced by local
+#          ./dynamic-plugins/dist path. used by the dynamic-plugin e2e job to
+#          test this branch's export-dynamic output rather than published npm.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,141 +27,95 @@ source "${SCRIPT_DIR}/lib.sh"
 FRONTEND_PKG="@kuadrant/kuadrant-backstage-plugin-frontend"
 BACKEND_PKG="@kuadrant/kuadrant-backstage-plugin-backend-dynamic"
 
-# --- prerequisites ---
+PLUGIN_SOURCE="${PLUGIN_SOURCE:-npm}"
+RHDH_IMAGE_REPOSITORY="${RHDH_IMAGE_REPOSITORY:-localhost/kuadrant-rhdh-e2e}"
+RHDH_IMAGE_TAG="${RHDH_IMAGE_TAG:-ci}"
+# rhdh addon chart pin (rhdh@<version>). empty = addon default (6.2.2, paired
+# with the rhdh:1.10 image line). the chart carries no appVersion, so this
+# tracks the base image by release; bump both together.
+RHDH_CHART_VERSION="${RHDH_CHART_VERSION:-}"
+# the addon exposes rhdh via an openshift route on the http port oinc maps
+# (default 9080); no port-forward. override if oinc create used a custom
+# --http-port.
+#
+# the hostname has to sit under .localhost. browsers treat *.localhost as a
+# potentially-trustworthy origin (whatwg secure contexts), so plain http there is
+# still a secure context; a real hostname like *.nip.io is not, and without a
+# secure context window.crypto.subtle, crypto.randomUUID and navigator.clipboard
+# are all undefined - which breaks requesting a key and every copy button.
+# oinc v0.3.1 hardcodes its own route host, so the overlay below overrides it.
+RHDH_URL="${RHDH_URL:-http://rhdh.localhost:9080}"
+# dex issuer, as setup-dex.sh serves it. one string for the browser and the pod
+# both - see oinc/manifests/dex.yaml for how that is arranged.
+DEX_URL="${DEX_URL:-http://dex.localhost:9080}"
 
+# the route matches on host alone, so global.host takes the url without scheme
+# or port. derived here so RHDH_URL stays the single place the address is set.
+RHDH_HOST="${RHDH_URL#*://}"
+RHDH_HOST="${RHDH_HOST%%/*}"
+RHDH_HOST="${RHDH_HOST%%:*}"
+
+case "${PLUGIN_SOURCE}" in
+  npm | baked) ;;
+  *)
+    log "error: PLUGIN_SOURCE must be 'npm' or 'baked', got '${PLUGIN_SOURCE}'"
+    exit 1
+    ;;
+esac
+
+RHDH_OVERLAY=""
+cleanup() {
+  [ -n "${RHDH_OVERLAY}" ] && rm -f "${RHDH_OVERLAY}"
+  return 0
+}
+trap cleanup EXIT
+
+# --- prerequisites + kube credentials ---
+
+check_command oinc "Install from https://github.com/jasonmadigan/oinc"
 check_command kubectl "Install from https://kubernetes.io/docs/tasks/tools/"
 check_command helm "Install from https://helm.sh/docs/intro/install/"
-check_command npm "Install from https://nodejs.org/"
+[ "${PLUGIN_SOURCE}" = "npm" ] && check_command npm "Install from https://nodejs.org/"
 
 kubectl get crd kuadrants.kuadrant.io &>/dev/null || {
   log "error: kuadrant CRDs not found. Run setup-cluster.sh first."
   exit 1
 }
 
-# --- RHDH SA + RBAC ---
+# RHDH always uses the same Dex-backed personas, regardless of plugin source or
+# whether this script was reached through `yarn oinc` or `yarn oinc:rhdh`.
+"${SCRIPT_DIR}/setup-dex.sh"
 
 log "applying RHDH service account and RBAC..."
-kubectl apply -f "${SCRIPT_DIR}/manifests/rhdh-sa.yaml"
-
-# --- generate SA token ---
+kubectl apply \
+  -f "${REPO_DIR}/kuadrant-dev-setup/rbac/rhdh-cluster-role.yaml" \
+  -f "${SCRIPT_DIR}/manifests/rhdh-sa.yaml"
 
 SA_TOKEN=$(kubectl create token rhdh-kuadrant -n rhdh --duration=8760h)
 CLUSTER_URL="https://kubernetes.default.svc"
 
-# --- fetch plugin integrity hashes ---
+# --- plugin integrity hashes (npm source only) ---
 
-log "fetching plugin integrity hashes..."
-FRONTEND_HASH=$(npm view "${FRONTEND_PKG}" dist.integrity)
-BACKEND_HASH=$(npm view "${BACKEND_PKG}" dist.integrity)
-log "frontend: ${FRONTEND_HASH}"
-log "backend:  ${BACKEND_HASH}"
+if [ "${PLUGIN_SOURCE}" = "npm" ]; then
+  log "fetching plugin integrity hashes..."
+  FRONTEND_HASH=$(npm view "${FRONTEND_PKG}" dist.integrity)
+  BACKEND_HASH=$(npm view "${BACKEND_PKG}" dist.integrity)
+  log "frontend: ${FRONTEND_HASH}"
+  log "backend:  ${BACKEND_HASH}"
+fi
 
-# --- RHDH configuration ---
+# --- helm values overlay ---
 
-log "creating RHDH configuration..."
-
-kubectl apply -n rhdh -f - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: app-config-rhdh
-  namespace: rhdh
-data:
-  app-config-kuadrant.yaml: |
-    app:
-      baseUrl: http://localhost:7007
-    backend:
-      baseUrl: http://localhost:7007
-      cors:
-        origin: http://localhost:7007
-
-    auth:
-      environment: development
-      providers:
-        guest:
-          dangerouslyAllowOutsideDevelopment: true
-          userEntityRef: user:default/guest
-
-    kubernetes:
-      serviceLocatorMethod:
-        type: multiTenant
-      clusterLocatorMethods:
-        - type: config
-          clusters:
-            - name: oinc
-              url: \${K8S_CLUSTER_URL}
-              authProvider: serviceAccount
-              serviceAccountToken: \${K8S_CLUSTER_TOKEN}
-              skipTLSVerify: true
-
-    catalog:
-      rules:
-        - allow: [Component, API, APIProduct, Location, Template, Domain, User, Group, System, Resource, Plugin, Package]
-
-    permission:
-      enabled: true
-      rbac:
-        admin:
-          superUsers:
-            - name: user:default/guest
-        policies-csv-file: /opt/app-root/src/rbac/rbac-policy.csv
-        policyFileReload: true
-
-    extensions:
-      installation:
-        enabled: true
-        saveToSingleFile:
-          file: /opt/app-root/src/dynamic-plugins-root/dynamic-plugins.yaml
-EOF
-
-# rbac policy from repo root, with guest as api-admin for local dev
-OINC_RBAC=$(mktemp)
-cat "${REPO_DIR}/rbac-policy.csv" > "${OINC_RBAC}"
-echo "g, user:default/guest, role:default/api-admin" >> "${OINC_RBAC}"
-kubectl create configmap rbac-policy-rhdh \
-  --namespace rhdh \
-  --from-file=rbac-policy.csv="${OINC_RBAC}" \
-  --dry-run=client -o yaml | kubectl apply -f -
-rm -f "${OINC_RBAC}"
-
-# k8s credentials secret
-kubectl apply -n rhdh -f - <<EOF
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhdh-k8s-credentials
-  namespace: rhdh
-type: Opaque
-stringData:
-  K8S_CLUSTER_URL: "${CLUSTER_URL}"
-  K8S_CLUSTER_TOKEN: "${SA_TOKEN}"
-EOF
-
-# --- RHDH via Helm ---
-
-log "installing RHDH via Helm..."
-helm repo add rhdh https://redhat-developer.github.io/rhdh-chart/ --force-update
-
-RHDH_VALUES=$(mktemp)
-cat > "${RHDH_VALUES}" <<VALS
-global:
-  dynamic:
-    includes:
-      - dynamic-plugins.default.yaml
-    plugins:
-      # rbac management ui
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
-        disabled: false
-      - package: "${BACKEND_PKG}"
-        disabled: false
-        integrity: "${BACKEND_HASH}"
-      - package: "${FRONTEND_PKG}"
-        disabled: false
-        integrity: "${FRONTEND_HASH}"
+# frontend dynamic plugin config (routes, menu items, mount points). identical
+# across plugin sources, so defined once and injected into the frontend entry.
+FRONTEND_PLUGIN_CONFIG=$(
+  cat <<'PCFG'
         pluginConfig:
           dynamicPlugins:
             frontend:
               kuadrant.kuadrant-backstage-plugin-frontend:
+                apiFactories:
+                  - importName: kuadrantApiFactory
                 appIcons:
                   - name: kuadrantIcon
                     importName: KuadrantIcon
@@ -182,8 +151,33 @@ global:
                     parent: kuadrant
                   kuadrant.api-key-approval:
                     parent: kuadrant
+                entityTabs:
+                  - mountPoint: entity.page.api-keys
+                    path: /api-keys
+                    title: API Keys
+                  - mountPoint: entity.page.api-product-info
+                    path: /api-product-info
+                    title: API Product Info
                 mountPoints:
-                  - mountPoint: entity.page.api/cards
+                  # overview card, only for api-key products. hasAnnotation tests
+                  # presence, and the entity provider emits kuadrant.io/auth-apikey
+                  # only when an api-key scheme is discovered (oidc-only omits it).
+                  - mountPoint: entity.page.overview/cards
+                    importName: EntityKuadrantApiAccessCard
+                    config:
+                      layout:
+                        gridColumnEnd:
+                          lg: "span 6"
+                          md: "span 6"
+                          xs: "span 12"
+                      if:
+                        allOf:
+                          - isKind: api
+                          - hasAnnotation: kuadrant.io/auth-apikey
+                  # the api keys tab has no static content, so it is shown only when
+                  # this card is mounted; gating the card on the annotation hides the
+                  # tab for oidc-only apis.
+                  - mountPoint: entity.page.api-keys/cards
                     importName: EntityKuadrantApiKeyManagementTab
                     config:
                       layout:
@@ -191,7 +185,8 @@ global:
                       if:
                         allOf:
                           - isKind: api
-                  - mountPoint: entity.page.api/cards
+                          - hasAnnotation: kuadrant.io/auth-apikey
+                  - mountPoint: entity.page.api-product-info/cards
                     importName: EntityKuadrantApiProductInfoContent
                     config:
                       layout:
@@ -199,58 +194,65 @@ global:
                       if:
                         allOf:
                           - isKind: api
+PCFG
+)
+
+# Only the package references differ between published and baked plugins.
+if [ "${PLUGIN_SOURCE}" = "npm" ]; then
+  KUADRANT_PLUGINS=$(cat <<EOF
+      - package: "${BACKEND_PKG}"
+        disabled: false
+        integrity: "${BACKEND_HASH}"
+      - package: "${FRONTEND_PKG}"
+        disabled: false
+        integrity: "${FRONTEND_HASH}"
+EOF
+  )
+else
+  KUADRANT_PLUGINS=$(cat <<'EOF'
+      - package: ./dynamic-plugins/dist/kuadrant-kuadrant-backstage-plugin-backend-dynamic
+        disabled: false
+      - package: ./dynamic-plugins/dist/kuadrant-kuadrant-backstage-plugin-frontend
+        disabled: false
+EOF
+  )
+fi
+
+PLUGINS_BLOCK=$(cat <<EOF
+    plugins:
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+        disabled: false
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-quickstart
+        disabled: true
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights-dynamic
+        disabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
+        disabled: true
+${KUADRANT_PLUGINS}
+${FRONTEND_PLUGIN_CONFIG}
+EOF
+)
+
+RHDH_OVERLAY=$(mktemp)
+cat >"${RHDH_OVERLAY}" <<VALS
+global:
+  # oinc v0.3.1 pins its route host to <name>.127.0.0.1.nip.io and derives the
+  # baseUrls from it. --rhdh-values is layered user-wins, so restating the four
+  # of them here moves rhdh onto the secure-context origin; they are one map
+  # merge over the addon's, not a replacement, so guest auth below is untouched.
+  host: ${RHDH_HOST}
+  dynamic:
+${PLUGINS_BLOCK}
 
 upstream:
   backstage:
     appConfig:
       app:
-        baseUrl: http://localhost:7007
+        baseUrl: ${RHDH_URL}
       backend:
-        baseUrl: http://localhost:7007
+        baseUrl: ${RHDH_URL}
         cors:
-          origin: http://localhost:7007
-    initContainers:
-      - name: install-dynamic-plugins
-        image: '{{ include "backstage.image" . }}'
-        command:
-          - /bin/bash
-          - -c
-          - |
-            ./install-dynamic-plugins.sh /dynamic-plugins-root
-            # seed the extensions installation file so the UI can manage plugins
-            cp /opt/app-root/src/dynamic-plugins.yaml /dynamic-plugins-root/dynamic-plugins.yaml
-        env:
-          - name: NPM_CONFIG_USERCONFIG
-            value: /opt/app-root/src/.npmrc.dynamic-plugins
-          - name: MAX_ENTRY_SIZE
-            value: "30000000"
-        workingDir: /opt/app-root/src
-        volumeMounts:
-          - mountPath: /dynamic-plugins-root
-            name: dynamic-plugins-root
-          - mountPath: /opt/app-root/src/dynamic-plugins.yaml
-            name: dynamic-plugins
-            readOnly: true
-            subPath: dynamic-plugins.yaml
-          - mountPath: /opt/app-root/src/.npmrc.dynamic-plugins
-            name: dynamic-plugins-npmrc
-            readOnly: true
-            subPath: .npmrc
-          - mountPath: /opt/app-root/src/.config/containers
-            name: dynamic-plugins-registry-auth
-            readOnly: true
-          - mountPath: /opt/app-root/src/.npm/_cacache
-            name: npmcacache
-          - name: temp
-            mountPath: /tmp
-        resources:
-          requests:
-            cpu: 250m
-            memory: 256Mi
-          limits:
-            cpu: 1000m
-            memory: 2.5Gi
-            ephemeral-storage: 5Gi
+          origin: ${RHDH_URL}
     extraAppConfig:
       - configMapRef: app-config-rhdh
         filename: app-config-kuadrant.yaml
@@ -265,6 +267,8 @@ upstream:
         mountPath: /tmp
       - name: rbac-policy
         mountPath: /opt/app-root/src/rbac
+      - name: catalog-entities
+        mountPath: /opt/app-root/src/catalog-entities
     extraVolumes:
       - name: dynamic-plugins-root
         emptyDir: {}
@@ -292,42 +296,170 @@ upstream:
       - name: rbac-policy
         configMap:
           name: rbac-policy-rhdh
-  postgresql:
-    primary:
-      persistence:
-        enabled: false
-      resources:
-        limits:
-          ephemeral-storage: 2Gi
+      - name: catalog-entities
+        configMap:
+          name: catalog-entities-rhdh
 VALS
 
-helm install rhdh rhdh/backstage \
+# --- rhdh configuration ---
+
+# the addon owns app/backend baseUrl (the route url) and cors; this configmap
+# adds the kuadrant-specific app-config: dex oidc sign-in, the user/group
+# entities the resolver and rbac need, the k8s cluster locator (sa token),
+# catalog rules and rbac. backstage merges it after the addon's config.
+#
+# the addon also configures guest auth. signInPage below moves the sign-in page
+# onto oidc so nothing arrives as guest, which is what makes the multi-user
+# specs meaningful here: personas come from dex and their roles from group
+# membership, exactly as under `yarn dev`.
+log "creating RHDH configuration..."
+
+# the user and group entities the emailMatchingUserEntityProfileEmail resolver
+# resolves dex logins against, and that rbac-policy.csv maps to roles. mounted
+# from the repo file rather than restated, so the personas have one definition
+# across `yarn dev` and here.
+kubectl create configmap catalog-entities-rhdh \
   --namespace rhdh \
-  --values "${RHDH_VALUES}" \
-  --timeout 900s \
-  --wait
-rm -f "${RHDH_VALUES}"
+  --from-file=kuadrant-users.yaml="${REPO_DIR}/catalog-entities/kuadrant-users.yaml" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl apply -n rhdh -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config-rhdh
+  namespace: rhdh
+data:
+  app-config-kuadrant.yaml: |
+    signInPage: oidc
+
+    auth:
+      environment: development
+      # the oidc provider is session-backed; without this it answers
+      # /api/auth/oidc/start with "authentication requires session support".
+      # secure: false because this environment is served over plain http (the
+      # .localhost origin is a secure context to the browser, but the cookie
+      # flag is about the scheme).
+      session:
+        secret: oinc-dev-session-secret-not-for-production
+        absoluteTimeoutSeconds: 604800
+        cookie:
+          secure: false
+          sameSite: lax
+          path: /
+      providers:
+        oidc:
+          development:
+            metadataUrl: ${DEX_URL}/.well-known/openid-configuration
+            clientId: backstage
+            clientSecret: backstage-dev-secret
+            title: OIDC
+            # the provider asks for openid/profile/email only, so dex issues no
+            # refresh token and the session dies on the first full page load -
+            # every spec navigates, so that is every spec. offline_access is what
+            # makes dex mint one. (the option is additionalScopes; the module
+            # rejects "scope" outright.)
+            additionalScopes:
+              - offline_access
+            signIn:
+              resolvers:
+                - resolver: emailMatchingUserEntityProfileEmail
+
+    kubernetes:
+      serviceLocatorMethod:
+        type: multiTenant
+      clusterLocatorMethods:
+        - type: config
+          clusters:
+            - name: oinc
+              url: \${K8S_CLUSTER_URL}
+              authProvider: serviceAccount
+              serviceAccountToken: \${K8S_CLUSTER_TOKEN}
+              skipTLSVerify: true
+
+    catalog:
+      rules:
+        - allow: [Component, API, APIProduct, Location, Template, Domain, User, Group, System, Resource, Plugin, Package]
+      locations:
+        - type: file
+          target: /opt/app-root/src/catalog-entities/kuadrant-users.yaml
+
+    permission:
+      enabled: true
+      rbac:
+        admin:
+          superUsers:
+            - name: user:default/admin
+        policies-csv-file: /opt/app-root/src/rbac/rbac-policy.csv
+        policyFileReload: true
+EOF
+
+# rbac policy from repo root, verbatim. it already grants the three groups their
+# roles, and the dex personas are members of those groups, so nothing is
+# appended here - the roles a persona gets are the ones they get under
+# `yarn dev`.
+kubectl create configmap rbac-policy-rhdh \
+  --namespace rhdh \
+  --from-file=rbac-policy.csv="${REPO_DIR}/rbac-policy.csv" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# k8s credentials secret
+kubectl apply -n rhdh -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhdh-k8s-credentials
+  namespace: rhdh
+type: Opaque
+stringData:
+  K8S_CLUSTER_URL: "${CLUSTER_URL}"
+  K8S_CLUSTER_TOKEN: "${SA_TOKEN}"
+EOF
+
+# --- rhdh via the oinc addon ---
+
+# the addon installs the rhdh/backstage chart, applies the microshift workarounds
+# and exposes rhdh via a route; --rhdh-values layers the kuadrant overlay on top
+# (user-wins), --rhdh-image points the deployment at the sideloaded derived image.
+log "installing RHDH via oinc rhdh addon (plugin source: ${PLUGIN_SOURCE})..."
+
+# on a fresh cluster the pod starts after the configmaps above and picks them up.
+# on a re-run it does not: the configmaps change but the pod spec does not, so
+# helm has nothing to roll and rhdh keeps serving the old app-config. noted here
+# rather than always restarting, which would cost a second rollout wait on the
+# fresh path that ci and `make dynamic-up` take.
+RHDH_EXISTED=""
+kubectl -n rhdh get deploy rhdh-developer-hub &>/dev/null && RHDH_EXISTED=1
+
+ADDON_SPEC="rhdh"
+[ -n "${RHDH_CHART_VERSION}" ] && ADDON_SPEC="rhdh@${RHDH_CHART_VERSION}"
+
+ADDON_ARGS=(addon install "${ADDON_SPEC}" --rhdh-values "${RHDH_OVERLAY}")
+if [ "${PLUGIN_SOURCE}" = "baked" ]; then
+  ADDON_ARGS+=(--rhdh-image "${RHDH_IMAGE_REPOSITORY}:${RHDH_IMAGE_TAG}")
+fi
+oinc "${ADDON_ARGS[@]}"
+
+if [ -n "${RHDH_EXISTED}" ]; then
+  log "rhdh already existed - restarting so it picks up the app-config changes..."
+  kubectl -n rhdh rollout restart deployment/rhdh-developer-hub
+  kubectl -n rhdh rollout status deployment/rhdh-developer-hub --timeout=300s
+fi
 
 # --- verify ---
 
 log "verifying RHDH deployment..."
 kubectl -n rhdh get pods
-log "RHDH is running"
-
-# --- done ---
-
-RHDH_SVC=$(kubectl -n rhdh get svc -l app.kubernetes.io/component=backstage -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "rhdh-developer-hub")
-RHDH_PORT=$(kubectl -n rhdh get svc "${RHDH_SVC}" -o jsonpath='{.spec.ports[0].port}' 2>/dev/null || echo "7007")
+log "RHDH installed; addon waited on rollout, npm init container may still be pulling"
 
 echo ""
 echo "============================================"
 echo " RHDH installed"
 echo "============================================"
 echo ""
-echo " RHDH:"
-echo "   kubectl port-forward svc/${RHDH_SVC} 7007:${RHDH_PORT} -n rhdh"
-echo "   http://localhost:7007/kuadrant"
+echo " RHDH (route, no port-forward):"
+echo "   ${RHDH_URL}/kuadrant"
 echo ""
 echo " Verify plugins:"
-echo "   curl -H 'Authorization: Bearer <token>' http://localhost:7007/api/dynamic-plugins-info/loaded-plugins"
+echo "   curl -H 'Authorization: Bearer <token>' ${RHDH_URL}/api/dynamic-plugins-info/loaded-plugins"
 echo ""

--- a/oinc/setup.sh
+++ b/oinc/setup.sh
@@ -5,9 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 case "${1:-}" in
   --cluster) exec "${SCRIPT_DIR}/setup-cluster.sh" ;;
+  --dex)     exec "${SCRIPT_DIR}/setup-dex.sh" ;;
   --rhdh)    exec "${SCRIPT_DIR}/setup-rhdh.sh" ;;
   *)
     "${SCRIPT_DIR}/setup-cluster.sh"
+    # setup-rhdh owns Dex so this and `yarn oinc:rhdh` cannot diverge.
     "${SCRIPT_DIR}/setup-rhdh.sh"
     ;;
 esac

--- a/oinc/teardown.sh
+++ b/oinc/teardown.sh
@@ -6,6 +6,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "${SCRIPT_DIR}/lib.sh"
 
+# ci teardown runs on always(); a failed oinc install must not fail the job here.
+# also covers local runs before oinc is installed.
+if ! command -v oinc &>/dev/null; then
+  log "oinc not installed, nothing to tear down"
+  exit 0
+fi
+
 log "deleting oinc cluster..."
 oinc delete --force
 

--- a/plugins/kuadrant-backend/src/k8s-client.ts
+++ b/plugins/kuadrant-backend/src/k8s-client.ts
@@ -23,6 +23,72 @@ export interface K8sList {
   items: K8sResource[];
 }
 
+// one field:message pair from a validation failure, e.g.
+// { field: 'spec.planTier', message: 'Unsupported value: "platinum"' }
+export interface K8sStatusCause {
+  field?: string;
+  message?: string;
+}
+
+// the api server's Status.details. kind is what tells "no such object of a kind
+// i know" apart from "no such kind", causes carry per-field validation
+// feedback, and retryAfterSeconds comes back with a throttled request.
+export interface K8sStatusDetails {
+  kind?: string;
+  name?: string;
+  group?: string;
+  causes?: K8sStatusCause[];
+  retryAfterSeconds?: number;
+}
+
+/**
+ * a kubernetes api failure, carrying the status the api server returned.
+ *
+ * the status is what tells a permission problem apart from a real fault, so it
+ * has to survive the client: without it the router can only answer 500, and a
+ * missing rbac rule reads as "server error" in the ui.
+ *
+ * reason and details survive alongside it because the status alone is
+ * ambiguous: a 404 is either a missing object or a missing crd, and only
+ * details tells them apart.
+ */
+export class K8sApiError extends Error {
+  readonly statusCode?: number;
+  readonly reason?: string;
+  readonly details?: K8sStatusDetails;
+
+  constructor(
+    message: string,
+    statusCode?: number,
+    reason?: string,
+    details?: K8sStatusDetails,
+  ) {
+    super(message);
+    this.name = 'K8sApiError';
+    this.statusCode = statusCode;
+    this.reason = reason;
+    this.details = details;
+  }
+}
+
+// @kubernetes/client-node puts the status on error.response, older shapes carry
+// it on the error itself, and the body holds the api server's own message.
+function k8sApiError(operation: string, error: any): K8sApiError {
+  const statusCode =
+    error?.response?.statusCode ?? error?.statusCode ?? error?.body?.code;
+  const body = error?.response?.body ?? error?.body;
+  const message = body?.message ?? error?.message;
+  const reason = body?.reason;
+  const details = body?.details;
+
+  return new K8sApiError(
+    `failed to ${operation}: ${message}${reason ? ` (${reason})` : ''}`,
+    typeof statusCode === 'number' ? statusCode : undefined,
+    typeof reason === 'string' ? reason : undefined,
+    details && typeof details === 'object' ? (details as K8sStatusDetails) : undefined,
+  );
+}
+
 export class KuadrantK8sClient {
   private kc: k8s.KubeConfig;
   private customApi: k8s.CustomObjectsApi;
@@ -137,7 +203,7 @@ export class KuadrantK8sClient {
 
       return response.body as K8sList;
     } catch (error: any) {
-      throw new Error(`failed to list ${plural}: ${error.message}`);
+      throw k8sApiError(`list ${plural}`, error);
     }
   }
 
@@ -158,7 +224,7 @@ export class KuadrantK8sClient {
       );
       return response.body as K8sResource;
     } catch (error: any) {
-      throw new Error(`failed to get ${plural}/${name}: ${error.message}`);
+      throw k8sApiError(`get ${plural}/${name}`, error);
     }
   }
 
@@ -167,7 +233,7 @@ export class KuadrantK8sClient {
       const response = await this.coreApi.createNamespacedSecret(namespace, secret as k8s.V1Secret);
       return response.body as K8sResource;
     } catch (error: any) {
-      throw new Error(`failed to create secret: ${error.message}`);
+      throw k8sApiError('create secret', error);
     }
   }
 
@@ -176,7 +242,7 @@ export class KuadrantK8sClient {
       const response = await this.coreApi.readNamespacedSecret(name, namespace);
       return response.body as K8sResource;
     } catch (error: any) {
-      throw new Error(`failed to get secret: ${error.message}`);
+      throw k8sApiError('get secret', error);
     }
   }
 
@@ -184,7 +250,7 @@ export class KuadrantK8sClient {
     try {
       await this.coreApi.deleteNamespacedSecret(name, namespace);
     } catch (error: any) {
-      throw new Error(`failed to delete secret: ${error.message}`);
+      throw k8sApiError('delete secret', error);
     }
   }
 
@@ -219,7 +285,7 @@ export class KuadrantK8sClient {
         details: JSON.stringify(details),
       });
 
-      throw new Error(`failed to create ${plural}: ${message}${reason ? ` (${reason})` : ''}`);
+      throw k8sApiError(`create ${plural}`, error);
     }
   }
 
@@ -239,7 +305,7 @@ export class KuadrantK8sClient {
         name,
       );
     } catch (error: any) {
-      throw new Error(`failed to delete ${plural}/${name}: ${error.message}`);
+      throw k8sApiError(`delete ${plural}/${name}`, error);
     }
   }
 
@@ -270,7 +336,7 @@ export class KuadrantK8sClient {
       );
       return response.body as K8sResource;
     } catch (error: any) {
-      throw new Error(`failed to patch ${plural}/${name}: ${error.message}`);
+      throw k8sApiError(`patch ${plural}/${name}`, error);
     }
   }
 
@@ -279,7 +345,7 @@ export class KuadrantK8sClient {
       const response = await this.coreApi.readNamespace(name);
       return response.body as K8sResource;
     } catch (error: any) {
-      throw error;
+      throw k8sApiError(`get namespace/${name}`, error);
     }
   }
 
@@ -288,8 +354,7 @@ export class KuadrantK8sClient {
       const response = await this.coreApi.createNamespace(namespace as k8s.V1Namespace);
       return response.body as K8sResource;
     } catch (error: any) {
-      throw new Error(`failed to create namespace: ${error.message}`);
+      throw k8sApiError('create namespace', error);
     }
   }
 }
-

--- a/plugins/kuadrant-backend/src/providers/APIProductEntityProvider.test.ts
+++ b/plugins/kuadrant-backend/src/providers/APIProductEntityProvider.test.ts
@@ -1,0 +1,93 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import { APIProductEntityProvider } from './APIProductEntityProvider';
+import { KuadrantK8sClient } from '../k8s-client';
+
+jest.mock('../k8s-client');
+
+// the kuadrant.io/auth-apikey annotation is presence-based: it is emitted only
+// when the product has an api-key auth scheme. rhdh dynamic-plugin hasAnnotation
+// conditions test presence, not value, so a 'false' value would be indistinguishable
+// from 'true' and would wrongly show the api keys tab/card for oidc-only apis.
+describe('APIProductEntityProvider auth-apikey annotation', () => {
+  let mockK8sClient: jest.Mocked<KuadrantK8sClient>;
+  let provider: APIProductEntityProvider;
+  let applyMutation: jest.Mock;
+
+  const product = (authentication?: Record<string, unknown>) => ({
+    apiVersion: 'devportal.kuadrant.io/v1alpha1',
+    kind: 'APIProduct',
+    metadata: {
+      name: 'test-api',
+      namespace: 'test-ns',
+      uid: 'uid-1',
+      resourceVersion: '1',
+      creationTimestamp: '2024-01-01T00:00:00Z',
+      annotations: { 'backstage.io/owner': 'group:default/team-a' },
+    },
+    spec: {
+      displayName: 'Test API',
+      publishStatus: 'Published',
+      approvalMode: 'manual',
+      targetRef: { group: 'gateway.networking.k8s.io', kind: 'HTTPRoute', name: 'test' },
+    },
+    status: authentication
+      ? { discoveredAuthScheme: { authentication } }
+      : {},
+  });
+
+  const syncedEntity = async () => {
+    await provider.refresh();
+    expect(applyMutation).toHaveBeenCalledTimes(1);
+    return applyMutation.mock.calls[0][0].entities[0].entity;
+  };
+
+  beforeEach(() => {
+    applyMutation = jest.fn();
+    mockK8sClient = {
+      listCustomResources: jest.fn(),
+    } as unknown as jest.Mocked<KuadrantK8sClient>;
+    (KuadrantK8sClient as jest.Mock).mockImplementation(() => mockK8sClient);
+    provider = new APIProductEntityProvider(mockServices.rootConfig());
+    (provider as unknown as { connection: unknown }).connection = { applyMutation };
+  });
+
+  it('omits the annotation for an oidc-only product', async () => {
+    mockK8sClient.listCustomResources.mockResolvedValue({
+      items: [product({ 'oidc-users': { jwt: { issuerUrl: 'https://oidc.example.com' } } })],
+    } as any);
+
+    const entity = await syncedEntity();
+
+    expect(entity.metadata.annotations?.['kuadrant.io/auth-apikey']).toBeUndefined();
+  });
+
+  it('sets the annotation to "true" for an api-key product', async () => {
+    mockK8sClient.listCustomResources.mockResolvedValue({
+      items: [product({ 'api-key-users': { apiKey: { selector: { matchLabels: {} } } } })],
+    } as any);
+
+    const entity = await syncedEntity();
+
+    expect(entity.metadata.annotations?.['kuadrant.io/auth-apikey']).toBe('true');
+  });
+
+  it('sets the annotation to "true" for a mixed jwt + api-key product', async () => {
+    mockK8sClient.listCustomResources.mockResolvedValue({
+      items: [product({ oidc: { jwt: {} }, keys: { apiKey: {} } })],
+    } as any);
+
+    const entity = await syncedEntity();
+
+    expect(entity.metadata.annotations?.['kuadrant.io/auth-apikey']).toBe('true');
+  });
+
+  it('omits the annotation when no auth scheme has been discovered', async () => {
+    mockK8sClient.listCustomResources.mockResolvedValue({
+      items: [product(undefined)],
+    } as any);
+
+    const entity = await syncedEntity();
+
+    expect(entity.metadata.annotations?.['kuadrant.io/auth-apikey']).toBeUndefined();
+  });
+});

--- a/plugins/kuadrant-backend/src/providers/APIProductEntityProvider.ts
+++ b/plugins/kuadrant-backend/src/providers/APIProductEntityProvider.ts
@@ -184,7 +184,13 @@ export class APIProductEntityProvider implements EntityProvider {
           'backstage.io/orphan-strategy': 'keep',
           'kuadrant.io/namespace': namespace,
           'kuadrant.io/apiproduct': name,
-          'kuadrant.io/auth-apikey': hasApiKey.toString(),
+          // presence-based: emitted only for api-key schemes. rhdh dynamic-plugin
+          // hasAnnotation conditions test presence not value, so emitting 'false'
+          // would wrongly match and show the api keys tab/card for oidc-only apis.
+          // static consumers use === 'true', which also holds when the key is absent.
+          ...(hasApiKey && {
+            'kuadrant.io/auth-apikey': 'true',
+          }),
           // add httproute annotation if we can infer it (usually same as apiproduct name without -api suffix)
           'kuadrant.io/httproute': name.endsWith('-api') ? name.slice(0, -4) : name,
           ...(product.spec.documentation?.openAPISpecURL && {

--- a/plugins/kuadrant-backend/src/router.test.ts
+++ b/plugins/kuadrant-backend/src/router.test.ts
@@ -265,9 +265,12 @@ describe('createRouter', () => {
 
       mockK8sClient.getCustomResource.mockResolvedValue(mockAPIKey);
 
-      // Mock secret fetch to throw error (not found)
+      // a genuine 404 from the api server: the referenced secret is gone
       mockK8sClient.getSecret.mockRejectedValue(
-        new Error('secret not found in cluster'),
+        Object.assign(
+          new Error('failed to get secret: secrets "missing" not found'),
+          { statusCode: 404 },
+        ),
       );
 
       const response = await request(app)
@@ -276,6 +279,35 @@ describe('createRouter', () => {
 
       expect(response.body).toEqual({
         error: 'secret not found',
+      });
+    });
+
+    it('does not turn a non-404 secret failure into a 404', async () => {
+      // a 403 is the backend's service account missing rbac, not a missing
+      // secret. it must reach the mapper, which logs it and answers generically
+      // rather than passing it off as not-found.
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ]);
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ]);
+
+      mockK8sClient.getCustomResource.mockResolvedValue(mockAPIKey);
+
+      mockK8sClient.getSecret.mockRejectedValue(
+        Object.assign(
+          new Error('failed to get secret: secrets is forbidden'),
+          { statusCode: 403 },
+        ),
+      );
+
+      const response = await request(app)
+        .get(`/apikeys/${namespace}/${name}/secret`)
+        .expect(500);
+
+      expect(response.body).toEqual({
+        error: 'failed to read api key secret',
       });
     });
 
@@ -365,6 +397,32 @@ describe('createRouter', () => {
         .post('/secrets')
         .send({ name: 'test-secret', apiKeyValue: 'test-key' })
         .expect(403);
+    });
+
+    it('does not leak the service account rbac detail on a create failure', async () => {
+      // a 403 from the api server is this backend's service account missing an
+      // rbac rule, and its message names the account, namespace and resource.
+      // that belongs in the operator log, not the response body.
+      mockAuthorizeFn.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ]);
+
+      mockK8sClient.createSecret.mockRejectedValue(
+        Object.assign(
+          new Error(
+            'failed to create secret: secrets is forbidden: User "system:serviceaccount:rhdh:rhdh" cannot create resource "secrets" in namespace "kuadrant-testuser-c7a65229"',
+          ),
+          { statusCode: 403 },
+        ),
+      );
+
+      const response = await request(app)
+        .post('/secrets')
+        .send({ name: 'test-secret', apiKeyValue: 'test-key-123' })
+        .expect(500);
+
+      expect(response.body.error).toBe('failed to create secret');
+      expect(response.body.error).not.toContain('serviceaccount');
     });
   });
 
@@ -1509,6 +1567,174 @@ describe('createRouter', () => {
         name,
         patchData,
       );
+    });
+  });
+  describe('kubernetes error propagation', () => {
+    // the status the api server returned has to survive the client, but only
+    // the statuses that describe the caller's own request should reach them as
+    // themselves. this backend talks to the api server as one service account
+    // and never impersonates the caller, so anything about that account's own
+    // access is the operator's problem, not the caller's.
+    const k8sError = (
+      statusCode: number,
+      message: string,
+      details?: Record<string, unknown>,
+    ) => Object.assign(new Error(message), { statusCode, details });
+
+    it('leaves a kubernetes 403 as 500 rather than blaming the caller', async () => {
+      // the caller got this far, so backstage's own permission check allowed
+      // them. a forbidden here is the backend's service account missing an rbac
+      // rule; answering 403 makes the ui tell the caller they lack access to
+      // the very thing they were just allowed to do.
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(403, 'failed to list apikeyrequests: apikeyrequests.devportal.kuadrant.io is forbidden'),
+      );
+
+      const response = await request(app).get('/requests').expect(500);
+
+      expect(response.body.error).toBe('failed to fetch api key requests');
+    });
+
+    it('maps a kubernetes 404 for a missing object to 404', async () => {
+      // details.kind means the api server knows the kind and simply has no such
+      // object: a real not-found, and the caller's to see.
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(404, 'failed to list apikeyrequests: apikeyrequests.devportal.kuadrant.io "missing" not found', {
+          group: 'devportal.kuadrant.io',
+          kind: 'apikeyrequests',
+          name: 'missing',
+        }),
+      );
+
+      const response = await request(app).get('/requests').expect(404);
+
+      expect(response.body.error).toBe('not found');
+    });
+
+    it('leaves a kubernetes 404 for a missing resource type as 500', async () => {
+      // the generic "could not find the requested resource" with no details is
+      // what the api server says when nothing serves the kind at all, i.e. the
+      // crds are not installed. answering 404 dresses an absent operator up as
+      // an ordinary empty result.
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(404, 'failed to list apikeyrequests: the server could not find the requested resource'),
+      );
+
+      const response = await request(app).get('/requests').expect(500);
+
+      expect(response.body.error).toBe('failed to fetch api key requests');
+    });
+
+    it('maps a kubernetes 429 to 503 and passes on the retry delay', async () => {
+      // the api server is throttling this backend's service account, not the
+      // caller. transient and worth retrying, but not the caller's fault.
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(429, 'failed to list apikeyrequests: too many requests', {
+          retryAfterSeconds: 7,
+        }),
+      );
+
+      const response = await request(app).get('/requests').expect(503);
+
+      expect(response.body.error).toBe('service temporarily unavailable');
+      expect(response.headers['retry-after']).toBe('7');
+    });
+
+    it('maps a kubernetes 429 with no retry delay to a bare 503', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(429, 'failed to list apikeyrequests: too many requests'),
+      );
+
+      const response = await request(app).get('/requests').expect(503);
+
+      expect(response.body.error).toBe('service temporarily unavailable');
+      expect(response.headers['retry-after']).toBeUndefined();
+    });
+
+    it('surfaces per-field validation causes on a 422', async () => {
+      // what the caller sent is theirs to see, and naming the field is the
+      // whole point of answering rather than a bare "invalid request".
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(422, 'failed to list apikeyrequests: APIKeyRequest is invalid', {
+          causes: [
+            {
+              field: 'spec.planTier',
+              message: 'Unsupported value: "platinum": supported values: "bronze", "silver", "gold"',
+            },
+          ],
+        }),
+      );
+
+      const response = await request(app).get('/requests').expect(422);
+
+      expect(response.body.error).toBe(
+        'spec.planTier: Unsupported value: "platinum": supported values: "bronze", "silver", "gold"',
+      );
+    });
+
+    it('falls back to a generic message when a 400 carries no causes', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(400, 'failed to list apikeyrequests: bad request'),
+      );
+
+      const response = await request(app).get('/requests').expect(400);
+
+      expect(response.body.error).toBe('invalid request');
+    });
+
+    it('maps a kubernetes 503 to a 503 and passes on the retry delay', async () => {
+      // the api server itself is unavailable, not the caller's doing. transient
+      // like a 429, and answered the same way.
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(503, 'failed to list apikeyrequests: the server is currently unable to handle the request', {
+          retryAfterSeconds: 3,
+        }),
+      );
+
+      const response = await request(app).get('/requests').expect(503);
+
+      expect(response.body.error).toBe('service temporarily unavailable');
+      expect(response.headers['retry-after']).toBe('3');
+    });
+
+    it('maps a kubernetes 503 with no retry delay to a bare 503', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(503, 'failed to list apikeyrequests: the server is currently unable to handle the request'),
+      );
+
+      const response = await request(app).get('/requests').expect(503);
+
+      expect(response.body.error).toBe('service temporarily unavailable');
+      expect(response.headers['retry-after']).toBeUndefined();
+    });
+
+    it('leaves an unmapped kubernetes status as 500', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(
+        k8sError(502, 'failed to list apikeyrequests: bad gateway'),
+      );
+
+      const response = await request(app).get('/requests').expect(500);
+
+      expect(response.body.error).toBe('failed to fetch api key requests');
+    });
+
+    it('leaves a failure carrying no status as 500', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.listCustomResources.mockRejectedValue(new Error('socket hang up'));
+
+      const response = await request(app).get('/requests').expect(500);
+
+      expect(response.body.error).toBe('failed to fetch api key requests');
     });
   });
 });

--- a/plugins/kuadrant-backend/src/router.ts
+++ b/plugins/kuadrant-backend/src/router.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import Router from 'express-promise-router';
 import cors from 'cors';
 import { randomBytes, createHash } from 'crypto';
-import { KuadrantK8sClient } from './k8s-client';
+import { KuadrantK8sClient, K8sStatusDetails } from './k8s-client';
 import { getAPIProductEntityProvider } from './module';
 import {
   kuadrantPermissions,
@@ -57,6 +57,135 @@ function getConsumerNamespace(userEntityRef: string): string {
   // (e.g. "foo_bar" and "foo.bar" both become "foo-bar")
   const hash = createHash('sha256').update(userEntityRef).digest('hex').substring(0, 8);
   return `kuadrant-${sanitized}-${hash}`;
+}
+
+// kubernetes statuses that describe the caller's own request, and so should
+// reach the caller as themselves. anything absent falls through to the
+// handler's own 500.
+//
+// deliberately absent:
+//   401 - this service's own service account token is bad, not anything the
+//         caller did.
+//   403 - the backend talks to the api server as a single service account and
+//         never impersonates the caller, so a forbidden is always that account
+//         missing an rbac rule. answering the caller "permission denied" blames
+//         them for an operator's problem, and the ui turns it into copy telling
+//         them they cannot do the very thing backstage's permission check just
+//         allowed. logged instead, where an operator can act on it.
+//   429 - the api server is throttling this client, not the caller. mapped to
+//         503 below, which keeps the transience without the blame.
+//   503 - the api server is unavailable, not anything the caller did. transient
+//         like a 429, and answered the same way: a 503 with a generic body.
+const K8S_STATUS_RESPONSES: Record<number, string> = {
+  400: 'invalid request',
+  404: 'not found',
+  409: 'conflict',
+  422: 'invalid request',
+};
+
+// read the status structurally rather than by instanceof: k8s-client wraps its
+// failures in K8sApiError, but the underlying client's errors carry the same
+// field and deserve the same mapping.
+function kubernetesStatus(error: unknown): number | undefined {
+  const statusCode = (error as { statusCode?: unknown } | null | undefined)?.statusCode;
+  return typeof statusCode === 'number' ? statusCode : undefined;
+}
+
+function kubernetesDetails(error: unknown): K8sStatusDetails | undefined {
+  const details = (error as { details?: unknown } | null | undefined)?.details;
+  return details && typeof details === 'object' ? (details as K8sStatusDetails) : undefined;
+}
+
+function kubernetesMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// a 404 carries two very different meanings. "no such object of a kind i know"
+// is an ordinary not-found and the caller's to see; "no such kind" means
+// nothing serves the resource at all, i.e. the crds are missing and the install
+// is broken. the api server fills details.kind for the first and leaves details
+// empty for the second, so read that rather than matching on message text.
+// no details at all is treated as the broken install: answering 404 there would
+// dress an absent operator up as an ordinary empty result.
+function isMissingResourceType(error: unknown): boolean {
+  return !kubernetesDetails(error)?.kind;
+}
+
+// per-field validation feedback describes what the caller sent, so it is theirs
+// to see. the surrounding message is not: it carries the resource path and
+// whatever namespace the operation touched.
+function validationDetail(error: unknown): string | undefined {
+  const causes = kubernetesDetails(error)?.causes;
+  if (!Array.isArray(causes)) {
+    return undefined;
+  }
+
+  const described = causes
+    .filter(cause => typeof cause?.message === 'string' && cause.message !== '')
+    .map(cause => (cause.field ? `${cause.field}: ${cause.message}` : cause.message));
+
+  return described.length > 0 ? described.join('; ') : undefined;
+}
+
+// answers a kubernetes failure with the matching status, or undefined so the
+// caller falls back to its own error handling. the k8s message is logged rather
+// than returned: it names the service account and the resource path, and the
+// status is what the ui acts on. returns the response it sent so handlers that
+// return one can pass it straight back.
+function sendKubernetesError(
+  res: express.Response,
+  error: unknown,
+): express.Response | undefined {
+  const status = kubernetesStatus(error);
+
+  if (status === undefined) {
+    return undefined;
+  }
+
+  // this backend's own service account, never the caller's. the message names
+  // the account and the resource, which is the rbac rule an operator has to add.
+  if (status === 403) {
+    console.error(
+      'kubernetes refused the service account this backend uses; grant it rbac for the resource named here:',
+      kubernetesMessage(error),
+    );
+    return undefined;
+  }
+
+  if (status === 429) {
+    console.error('kubernetes is throttling this backend:', kubernetesMessage(error));
+    const retryAfter = kubernetesDetails(error)?.retryAfterSeconds;
+    if (typeof retryAfter === 'number' && retryAfter > 0) {
+      res.setHeader('Retry-After', String(retryAfter));
+    }
+    return res.status(503).json({ error: 'service temporarily unavailable' });
+  }
+
+  if (status === 503) {
+    console.error('kubernetes is unavailable:', kubernetesMessage(error));
+    const retryAfter = kubernetesDetails(error)?.retryAfterSeconds;
+    if (typeof retryAfter === 'number' && retryAfter > 0) {
+      res.setHeader('Retry-After', String(retryAfter));
+    }
+    return res.status(503).json({ error: 'service temporarily unavailable' });
+  }
+
+  const message = K8S_STATUS_RESPONSES[status];
+  if (message === undefined) {
+    return undefined;
+  }
+
+  if (status === 404 && isMissingResourceType(error)) {
+    console.error(
+      'kubernetes serves no such resource type; check the kuadrant crds are installed:',
+      kubernetesMessage(error),
+    );
+    return undefined;
+  }
+
+  const detail = status === 400 || status === 422 ? validationDetail(error) : undefined;
+
+  return res.status(status).json({ error: detail ?? message });
 }
 
 async function ensureConsumerNamespace(k8sClient: KuadrantK8sClient, namespace: string): Promise<void> {
@@ -241,7 +370,7 @@ export async function createRouter({
       console.error('error fetching apiproducts:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch apiproducts' });
       }
     }
@@ -288,7 +417,7 @@ export async function createRouter({
       console.error('error fetching apiproduct:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch apiproduct' });
       }
     }
@@ -343,15 +472,17 @@ export async function createRouter({
       res.status(201).json(created);
     } catch (error) {
       console.error('error creating apiproduct:', error);
-      const errorMessage = error instanceof Error ? error.message : String(error);
 
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
       } else if (error instanceof InputError) {
         res.status(400).json({ error: error.message });
-      } else {
-        // pass the detailed error message to the frontend
-        res.status(500).json({ error: errorMessage });
+      } else if (!sendKubernetesError(res, error)) {
+        // anything the caller sent has already been answered above, with the
+        // field the api server objected to where it named one. what is left is
+        // a fault; the raw k8s message names the service account and namespace,
+        // so it stays in the log above and the response gets a generic line.
+        res.status(500).json({ error: 'failed to create apiproduct' });
       }
     }
   });
@@ -451,7 +582,7 @@ export async function createRouter({
       console.error('error deleting apiproduct:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to delete apiproduct' });
       }
     }
@@ -478,7 +609,7 @@ export async function createRouter({
       console.error('error fetching httproutes:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch httproutes' });
       }
     }
@@ -507,7 +638,7 @@ export async function createRouter({
       console.error('error fetching httproute:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch httproute' });
       }
     }
@@ -622,15 +753,17 @@ export async function createRouter({
       return res.json(updated);
     } catch (error) {
       console.error('error updating apiproduct:', error);
-      const errorMessage = error instanceof Error ? error.message : String(error);
 
       if (error instanceof NotAllowedError) {
         return res.status(403).json({ error: error.message });
-      } else if (error instanceof InputError) {
-        return res.status(400).json({ error: error.message });
-      } else {
-        return res.status(500).json({ error: errorMessage });
       }
+      if (error instanceof InputError) {
+        return res.status(400).json({ error: error.message });
+      }
+      return (
+        sendKubernetesError(res, error) ??
+        res.status(500).json({ error: 'failed to update apiproduct' })
+      );
     }
   });
 
@@ -679,7 +812,7 @@ export async function createRouter({
       console.error('error fetching planpolicies:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch planpolicies' });
       }
     }
@@ -705,7 +838,7 @@ export async function createRouter({
       console.error('error fetching planpolicy:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch planpolicy' });
       }
     }
@@ -771,9 +904,8 @@ export async function createRouter({
         res.status(403).json({ error: error.message });
       } else if (error instanceof InputError) {
         res.status(400).json({ error: error.message });
-      } else {
-        const errorMessage = error instanceof Error ? error.message : 'failed to create secret';
-        res.status(500).json({ error: errorMessage });
+      } else if (!sendKubernetesError(res, error)) {
+        res.status(500).json({ error: 'failed to create secret' });
       }
     }
   });
@@ -803,9 +935,8 @@ export async function createRouter({
       console.error('error deleting secret:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
-        const errorMessage = error instanceof Error ? error.message : 'failed to delete secret';
-        res.status(500).json({ error: errorMessage });
+      } else if (!sendKubernetesError(res, error)) {
+        res.status(500).json({ error: 'failed to delete secret' });
       }
     }
   });
@@ -901,11 +1032,12 @@ export async function createRouter({
       console.error('error creating api key request:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
-        // extract meaningful error message from kubernetes API errors
-        // this helps users understand validation failures (e.g., namespace not found, invalid tier)
-        const errorMessage = error instanceof Error ? error.message : 'failed to create api key request';
-        res.status(500).json({ error: errorMessage });
+      } else if (!sendKubernetesError(res, error)) {
+        // validation failures answer above, naming the field the api server
+        // rejected. what is left is a fault; the raw k8s message names the
+        // service account and namespace, so it stays in the log above and the
+        // response gets a generic line.
+        res.status(500).json({ error: 'failed to create api key request' });
       }
     }
   });
@@ -1005,7 +1137,7 @@ export async function createRouter({
       console.error('error fetching api key requests:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch api key requests' });
       }
     }
@@ -1065,7 +1197,7 @@ export async function createRouter({
       console.error('error fetching user api key requests:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch user api key requests' });
       }
     }
@@ -1142,7 +1274,7 @@ export async function createRouter({
       console.error('error approving api key request:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to approve api key request' });
       }
     }
@@ -1215,7 +1347,7 @@ export async function createRouter({
       console.error('error rejecting api key request:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to reject api key request' });
       }
     }
@@ -1309,7 +1441,7 @@ export async function createRouter({
       console.error('error in bulk approve:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to bulk approve api key requests' });
       }
     }
@@ -1395,7 +1527,7 @@ export async function createRouter({
       console.error('error in bulk reject:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to bulk reject api key requests' });
       }
     }
@@ -1443,7 +1575,7 @@ export async function createRouter({
       console.error('error deleting api key request:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to delete api key request' });
       }
     }
@@ -1540,7 +1672,7 @@ export async function createRouter({
         res.status(403).json({ error: error.message });
       } else if (error instanceof InputError) {
         res.status(400).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to update api key request' });
       }
     }
@@ -1595,7 +1727,7 @@ export async function createRouter({
       console.error('failed to get api key:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to get api key' });
       }
     }
@@ -1660,6 +1792,12 @@ export async function createRouter({
       try {
         secret = await k8sClient.getSecret(namespace, secretName);
       } catch (error) {
+        // only a real not-found is the caller's; anything else (a throttle, the
+        // service account missing an rbac rule) is for the mapper below, not
+        // dressed up as a missing secret.
+        if (kubernetesStatus(error) !== 404) {
+          throw error;
+        }
         console.error('error fetching secret:', error);
         res.status(404).json({
           error: 'secret not found',
@@ -1688,7 +1826,7 @@ export async function createRouter({
       console.error('error reading api key secret:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to read api key secret' });
       }
     }
@@ -1734,7 +1872,7 @@ export async function createRouter({
       console.error('error fetching authpolicies:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch authpolicies' });
       }
     }
@@ -1780,7 +1918,7 @@ export async function createRouter({
       console.error('error fetching ratelimitpolicies:', error);
       if (error instanceof NotAllowedError) {
         res.status(403).json({ error: error.message });
-      } else {
+      } else if (!sendKubernetesError(res, error)) {
         res.status(500).json({ error: 'failed to fetch ratelimitpolicies' });
       }
     }

--- a/plugins/kuadrant/src/components/CreateAPIProductDialog/CreateAPIProductDialog.tsx
+++ b/plugins/kuadrant/src/components/CreateAPIProductDialog/CreateAPIProductDialog.tsx
@@ -471,7 +471,7 @@ export const CreateAPIProductDialog = ({ open, onClose, onSuccess }: CreateAPIPr
               placeholder="API description"
               margin="normal"
               multiline
-              rows={2}
+              minRows={2}
               required
               disabled={creating}
               InputLabelProps={{

--- a/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
+++ b/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
@@ -132,7 +132,7 @@ export const EditAPIKeyDialog = ({
           label="Use Case"
           placeholder="Describe how you plan to use this API"
           multiline
-          rows={3}
+          minRows={3}
           fullWidth
           margin="normal"
           value={useCase}

--- a/plugins/kuadrant/src/components/EditAPIProductDialog/EditAPIProductDialog.tsx
+++ b/plugins/kuadrant/src/components/EditAPIProductDialog/EditAPIProductDialog.tsx
@@ -356,7 +356,7 @@ export const EditAPIProductDialog = ({ open, onClose, onSuccess, namespace, name
                   placeholder="API description"
                   margin="normal"
                   multiline
-                  rows={2}
+                  minRows={2}
                   required
                   disabled={saving}
                   InputLabelProps={{

--- a/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
@@ -184,7 +184,7 @@ export const RequestAccessDialog = ({
           label="Use Case (optional)"
           placeholder="Describe how you plan to use this API"
           multiline
-          rows={3}
+          minRows={3}
           fullWidth
           margin="normal"
           value={useCase}

--- a/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
@@ -301,7 +301,7 @@ export const SimpleRequestAccessDialog = ({
           label="Use case"
           placeholder="Briefly describe your specific use case of using this API key"
           multiline
-          rows={2}
+          minRows={2}
           fullWidth
           margin="normal"
           value={useCase}


### PR DESCRIPTION
## Summary

Closes #279.

Adds an opt-in path for testing the Kuadrant plugins as RHDH dynamic plugins:

- The existing static Backstage E2E job remains the default required PR path.
- `E2E (dynamic plugins)` is `workflow_dispatch` only.
- The path exports both plugins, bakes them into RHDH, starts an oinc cluster with Kuadrant, deploys Dex and RHDH, and runs the full Playwright suite.
- Local and oinc environments use the same Dex personas and RBAC policy.
- The shared RHDH ClusterRole has one source of truth.
- Versions and image coordinates can be overridden through Make variables.

The PR also includes fixes exercised by the dynamic environment: API-key annotation conditions, Kubernetes error propagation, live-backend E2E coverage, repeatable test state, and the deprecated MUI multiline field usage.

## Local use

```console
# Build and leave RHDH running for manual testing
make dynamic-up

# Run or repeat the E2E suite
make e2e-deps e2e-specs

# Remove the cluster
make teardown

# One-shot build, test, and teardown
make e2e-dynamic
```

`PLAYWRIGHT_ARGS` is forwarded by `make e2e-specs` for focused or headed runs.

## Verification

- Fresh local `make e2e-dynamic` completed the build, deployment, full suite, and teardown successfully: 84 passed and one passed on retry.
- A repeat full-suite run passed 85/85.
- Backend provider/router suites: 50 tests passed.
- TypeScript, lint, formatting, ShellCheck, actionlint, YAML, and Helm overlay checks passed.

The cold-run retry is an upstream developer-portal-controller v0.2.1 auto-approval ordering race; it is not a plugin or RHDH failure.

The manual workflow becomes dispatchable once its workflow file exists on the default branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual dynamic-plugin end-to-end testing workflow, with local commands to build, start, run specs, and tear down.
  * API key UI elements are shown only when API-key authentication is detected (not for OIDC-only products).
  * Expanded Dex-based quick-login usage to improve end-to-end test coverage.
* **Bug Fixes**
  * Improved backend error handling for missing resources, validation issues, throttling, and forbidden cases, while preventing sensitive RBAC/service-account details from leaking.
* **Documentation**
  * Updated CI and E2E guidance for dynamic plugins.
* **UI**
  * Multiline description/use-case fields can now grow beyond their initial height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->