### PR TITLE
chore: bump version to 0.4.0 for stable release

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "NODE_OPTIONS=--no-node-snapshot turbo run start --filter=backend",
     "dev": "yarn dev:setup-dex && concurrently \"yarn:dev:*\"",
     "dev:setup-dex": "bash scripts/setup-dex.sh",
-    "dev:dex": "docker run --rm --name kuadrant-dex -p 5556:5556 -v \"$(pwd)/kuadrant-dev-setup/dex/config.yaml:/etc/dex/config.yaml:ro\" -v \"$(pwd)/kuadrant-dev-setup/dex/web:/srv/dex/web:ro\" ghcr.io/dexidp/dex:latest dex serve /etc/dex/config.yaml",
+    "dev:dex": "docker run --rm --name kuadrant-dex -p 5556:5556 -v \"$(pwd)/kuadrant-dev-setup/dex/config.yaml:/etc/dex/config.yaml:ro\" -v \"$(pwd)/kuadrant-dev-setup/dex/web:/srv/dex/web:ro\" ghcr.io/dexidp/dex:v2.45.1 dex serve /etc/dex/config.yaml",
     "dev:backend": "NODE_OPTIONS=--no-node-snapshot turbo run start --filter=backend",
     "dev:frontend": "NODE_OPTIONS=--no-node-snapshot turbo run start --filter=app",
     "build": "turbo run build",

--- a/plugins/kuadrant-backend/package.json
+++ b/plugins/kuadrant-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuadrant/kuadrant-backstage-plugin-backend",
-  "version": "0.4.0-dev1",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/plugins/kuadrant/package.json
+++ b/plugins/kuadrant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuadrant/kuadrant-backstage-plugin-frontend",
-  "version": "0.4.0-dev1",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/scripts/setup-dex.sh
+++ b/scripts/setup-dex.sh
@@ -12,7 +12,7 @@ mkdir -p kuadrant-dev-setup/dex/web/templates
 # extract dex web files from container image
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$(pwd)/kuadrant-dev-setup/dex:/tmp/out" \
-  ghcr.io/dexidp/dex:latest \
+  ghcr.io/dexidp/dex:v2.45.1 \
   sh -c '
     cp -r /srv/dex/web/static /srv/dex/web/themes /srv/dex/web/robots.txt /tmp/out/web/
     for f in /srv/dex/web/templates/*.html; do


### PR DESCRIPTION
## Summary
- Remove `-dev1` suffix from plugin package versions (`0.4.0-dev1` → `0.4.0`)
- Prepares for the `v0.4.0` stable release from the `release-0.4` branch

## Next steps
After merge:
1. Tag: `git tag -a v0.4.0 -m "v0.4.0"`
2. Create GitHub Release from the tag
3. Publish workflow runs automatically