### PR TITLE
Add unit tests for kuadrant plugin utility functions

### DIFF
--- a/plugins/kuadrant/src/utils/errors.test.ts
+++ b/plugins/kuadrant/src/utils/errors.test.ts
@@ -1,0 +1,106 @@
+import { handleFetchError } from './errors';
+
+/**
+ * helper to create a mock Response with a given status and optional JSON body
+ */
+function mockResponse(
+  status: number,
+  body?: Record<string, unknown>,
+): Response {
+  return {
+    status,
+    json: body
+      ? () => Promise.resolve(body)
+      : () => Promise.reject(new Error('no body')),
+  } as unknown as Response;
+}
+
+describe('handleFetchError', () => {
+  describe('status 400', () => {
+    it('returns the error field from the response body when present', async () => {
+      const response = mockResponse(400, {
+        error: 'Name must be unique',
+      });
+      const result = await handleFetchError(response);
+      expect(result).toBe('Name must be unique');
+    });
+
+    it('returns the default message when response body has no error field', async () => {
+      const response = mockResponse(400, {});
+      const result = await handleFetchError(response);
+      expect(result).toBe('Invalid request. Please check your input.');
+    });
+
+    it('returns the default message when response body is not parseable', async () => {
+      const response = mockResponse(400);
+      const result = await handleFetchError(response);
+      expect(result).toBe('Invalid request. Please check your input.');
+    });
+  });
+
+  describe('status 403', () => {
+    it('returns permission denied message', async () => {
+      const response = mockResponse(403);
+      const result = await handleFetchError(response);
+      expect(result).toBe('Permission denied. Contact your administrator.');
+    });
+
+    it('returns permission denied message regardless of body content', async () => {
+      const response = mockResponse(403, {
+        error: 'custom error ignored',
+      });
+      const result = await handleFetchError(response);
+      expect(result).toBe('Permission denied. Contact your administrator.');
+    });
+  });
+
+  describe('status 404', () => {
+    it('returns resource not found message', async () => {
+      const response = mockResponse(404);
+      const result = await handleFetchError(response);
+      expect(result).toBe('Resource not found. It may have been deleted.');
+    });
+  });
+
+  describe('status 409', () => {
+    it('returns conflict message', async () => {
+      const response = mockResponse(409);
+      const result = await handleFetchError(response);
+      expect(result).toBe(
+        'Resource already exists or conflicts with existing data.',
+      );
+    });
+  });
+
+  describe('status 500', () => {
+    it('returns server error message', async () => {
+      const response = mockResponse(500);
+      const result = await handleFetchError(response);
+      expect(result).toBe(
+        'Server error. Please try again or contact support.',
+      );
+    });
+  });
+
+  describe('unknown status codes', () => {
+    it('returns the error field from the body when present', async () => {
+      const response = mockResponse(422, {
+        error: 'Unprocessable entity',
+      });
+      const result = await handleFetchError(response);
+      expect(result).toBe('Unprocessable entity');
+    });
+
+    it('returns a generic message with the status code when body has no error', async () => {
+      const response = mockResponse(503, {});
+      const result = await handleFetchError(response);
+      expect(result).toBe('Request failed (503)');
+    });
+
+    it('returns a generic message with the status code when body is not parseable', async () => {
+      const response = mockResponse(502);
+      const result = await handleFetchError(response);
+      expect(result).toBe('Request failed (502)');
+    });
+  });
+});

--- a/plugins/kuadrant/src/utils/permissions.test.ts
+++ b/plugins/kuadrant/src/utils/permissions.test.ts
@@ -1,0 +1,203 @@
+import { renderHook } from '@testing-library/react';
+import { usePermission } from '@backstage/plugin-permission-react';
+import { canDeleteResource, useKuadrantPermission } from './permissions';
+import { Permission, ResourcePermission } from '@backstage/plugin-permission-common';
+
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: jest.fn(),
+}));
+
+const mockUsePermission = usePermission as jest.MockedFunction<
+  typeof usePermission
+>;
+
+describe('canDeleteResource', () => {
+  describe('when user has canDeleteAll permission', () => {
+    it('returns true even if user is not the owner', () => {
+      expect(canDeleteResource('owner-1', 'user-2', false, true)).toBe(true);
+    });
+
+    it('returns true when user is also the owner', () => {
+      expect(canDeleteResource('user-1', 'user-1', false, true)).toBe(true);
+    });
+
+    it('returns true regardless of canDeleteOwn flag', () => {
+      expect(canDeleteResource('owner-1', 'user-2', true, true)).toBe(true);
+    });
+  });
+
+  describe('when user has canDeleteOwn permission', () => {
+    it('returns true when user is the owner', () => {
+      expect(canDeleteResource('user-1', 'user-1', true, false)).toBe(true);
+    });
+
+    it('returns false when user is not the owner', () => {
+      expect(canDeleteResource('owner-1', 'user-2', true, false)).toBe(false);
+    });
+  });
+
+  describe('when user has no delete permissions', () => {
+    it('returns false even if user is the owner', () => {
+      expect(canDeleteResource('user-1', 'user-1', false, false)).toBe(false);
+    });
+
+    it('returns false when user is not the owner', () => {
+      expect(canDeleteResource('owner-1', 'user-2', false, false)).toBe(false);
+    });
+  });
+});
+
+describe('useKuadrantPermission', () => {
+  beforeEach(() => {
+    mockUsePermission.mockReset();
+  });
+
+  describe('with a basic permission (no resourceType)', () => {
+    const basicPermission: Permission = {
+      type: 'basic',
+      name: 'kuadrant.apiproduct.list',
+      attributes: {},
+    };
+
+    it('returns allowed true when permission is granted', () => {
+      mockUsePermission.mockReturnValue({
+        loading: false,
+        allowed: true,
+      });
+
+      const { result } = renderHook(() =>
+        useKuadrantPermission(basicPermission),
+      );
+
+      expect(result.current).toEqual({
+        allowed: true,
+        loading: false,
+        error: undefined,
+      });
+    });
+
+    it('passes permission without resourceRef to usePermission', () => {
+      mockUsePermission.mockReturnValue({
+        loading: false,
+        allowed: false,
+      });
+
+      renderHook(() => useKuadrantPermission(basicPermission));
+
+      expect(mockUsePermission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          permission: basicPermission,
+        }),
+      );
+      // should not have resourceRef in the call
+      const callArg = mockUsePermission.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArg).not.toHaveProperty('resourceRef');
+    });
+
+    it('returns loading true while permission check is in progress', () => {
+      mockUsePermission.mockReturnValue({
+        loading: true,
+        allowed: false,
+      });
+
+      const { result } = renderHook(() =>
+        useKuadrantPermission(basicPermission),
+      );
+
+      expect(result.current).toEqual({
+        allowed: false,
+        loading: true,
+        error: undefined,
+      });
+    });
+
+    it('returns error when permission check fails', () => {
+      const error = new Error('Permission check failed');
+      mockUsePermission.mockReturnValue({
+        loading: false,
+        allowed: false,
+        error,
+      });
+
+      const { result } = renderHook(() =>
+        useKuadrantPermission(basicPermission),
+      );
+
+      expect(result.current).toEqual({
+        allowed: false,
+        loading: false,
+        error,
+      });
+    });
+  });
+
+  describe('with a resource permission (has resourceType)', () => {
+    const resourcePermission = {
+      type: 'resource',
+      name: 'kuadrant.apikey.create',
+      resourceType: 'kuadrant-apikey',
+      attributes: {},
+    } as ResourcePermission;
+
+    it('passes permission with resourceRef to usePermission', () => {
+      mockUsePermission.mockReturnValue({
+        loading: false,
+        allowed: true,
+      });
+
+      renderHook(() =>
+        useKuadrantPermission(
+          resourcePermission,
+          'apiproduct:default/my-api',
+        ),
+      );
+
+      expect(mockUsePermission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          permission: resourcePermission,
+          resourceRef: 'apiproduct:default/my-api',
+        }),
+      );
+    });
+
+    it('returns allowed true when resource permission is granted', () => {
+      mockUsePermission.mockReturnValue({
+        loading: false,
+        allowed: true,
+      });
+
+      const { result } = renderHook(() =>
+        useKuadrantPermission(
+          resourcePermission,
+          'apiproduct:default/my-api',
+        ),
+      );
+
+      expect(result.current).toEqual({
+        allowed: true,
+        loading: false,
+        error: undefined,
+      });
+    });
+
+    it('returns allowed false when resource permission is denied', () => {
+      mockUsePermission.mockReturnValue({
+        loading: false,
+        allowed: false,
+      });
+
+      const { result } = renderHook(() =>
+        useKuadrantPermission(
+          resourcePermission,
+          'apiproduct:default/my-api',
+        ),
+      );
+
+      expect(result.current).toEqual({
+        allowed: false,
+        loading: false,
+        error: undefined,
+      });
+    });
+  });
+});

--- a/plugins/kuadrant/src/utils/validation.test.ts
+++ b/plugins/kuadrant/src/utils/validation.test.ts
@@ -1,0 +1,153 @@
+import { validateKubernetesName, validateURL } from './validation';
+
+describe('validateKubernetesName', () => {
+  describe('valid names', () => {
+    it('accepts a simple lowercase name', () => {
+      expect(validateKubernetesName('my-api')).toBeNull();
+    });
+
+    it('accepts a single character name', () => {
+      expect(validateKubernetesName('a')).toBeNull();
+    });
+
+    it('accepts a single digit name', () => {
+      expect(validateKubernetesName('1')).toBeNull();
+    });
+
+    it('accepts a name with hyphens in the middle', () => {
+      expect(validateKubernetesName('my-cool-api')).toBeNull();
+    });
+
+    it('accepts a name starting and ending with digits', () => {
+      expect(validateKubernetesName('123-abc-456')).toBeNull();
+    });
+
+    it('accepts a name at exactly 253 characters', () => {
+      const name = 'a'.repeat(253);
+      expect(validateKubernetesName(name)).toBeNull();
+    });
+  });
+
+  describe('empty and whitespace', () => {
+    it('rejects an empty string', () => {
+      expect(validateKubernetesName('')).toBe('Name is required');
+    });
+
+    it('rejects a whitespace-only string', () => {
+      expect(validateKubernetesName('   ')).toBe('Name is required');
+    });
+
+    it('rejects a tab-only string', () => {
+      expect(validateKubernetesName('\t')).toBe('Name is required');
+    });
+  });
+
+  describe('length limit', () => {
+    it('rejects a name exceeding 253 characters', () => {
+      const name = 'a'.repeat(254);
+      expect(validateKubernetesName(name)).toBe(
+        'Must be 253 characters or less',
+      );
+    });
+  });
+
+  describe('DNS-1123 format violations', () => {
+    it('rejects uppercase letters', () => {
+      expect(validateKubernetesName('MyApi')).toBe(
+        'Must be lowercase alphanumeric with hyphens, start and end with alphanumeric',
+      );
+    });
+
+    it('rejects a name starting with a hyphen', () => {
+      expect(validateKubernetesName('-my-api')).toBe(
+        'Must be lowercase alphanumeric with hyphens, start and end with alphanumeric',
+      );
+    });
+
+    it('rejects a name ending with a hyphen', () => {
+      expect(validateKubernetesName('my-api-')).toBe(
+        'Must be lowercase alphanumeric with hyphens, start and end with alphanumeric',
+      );
+    });
+
+    it('rejects underscores', () => {
+      expect(validateKubernetesName('my_api')).toBe(
+        'Must be lowercase alphanumeric with hyphens, start and end with alphanumeric',
+      );
+    });
+
+    it('rejects dots', () => {
+      expect(validateKubernetesName('my.api')).toBe(
+        'Must be lowercase alphanumeric with hyphens, start and end with alphanumeric',
+      );
+    });
+
+    it('rejects spaces in the name', () => {
+      expect(validateKubernetesName('my api')).toBe(
+        'Must be lowercase alphanumeric with hyphens, start and end with alphanumeric',
+      );
+    });
+
+    it('rejects special characters', () => {
+      expect(validateKubernetesName('my@api!')).toBe(
+        'Must be lowercase alphanumeric with hyphens, start and end with alphanumeric',
+      );
+    });
+  });
+});
+
+describe('validateURL', () => {
+  describe('valid URLs', () => {
+    it('accepts a valid http URL', () => {
+      expect(validateURL('http://example.com')).toBeNull();
+    });
+
+    it('accepts a valid https URL', () => {
+      expect(validateURL('https://example.com')).toBeNull();
+    });
+
+    it('accepts an https URL with path and query', () => {
+      expect(validateURL('https://example.com/api/v1?key=val')).toBeNull();
+    });
+
+    it('accepts an https URL with port', () => {
+      expect(validateURL('https://example.com:8443/path')).toBeNull();
+    });
+  });
+
+  describe('empty and optional', () => {
+    it('returns null for an empty string (field is optional)', () => {
+      expect(validateURL('')).toBeNull();
+    });
+  });
+
+  describe('invalid URLs', () => {
+    it('rejects a non-URL string', () => {
+      expect(validateURL('not-a-url')).toBe('Must be a valid URL');
+    });
+
+    it('rejects a string with no scheme', () => {
+      expect(validateURL('example.com')).toBe('Must be a valid URL');
+    });
+  });
+
+  describe('non-http schemes', () => {
+    it('rejects ftp scheme', () => {
+      expect(validateURL('ftp://example.com')).toBe(
+        'Must be a valid HTTP or HTTPS URL',
+      );
+    });
+
+    it('rejects mailto scheme', () => {
+      expect(validateURL('mailto:user@example.com')).toBe(
+        'Must be a valid HTTP or HTTPS URL',
+      );
+    });
+
+    it('rejects file scheme', () => {
+      expect(validateURL('file:///etc/passwd')).toBe(
+        'Must be a valid HTTP or HTTPS URL',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 52 unit tests for 3 untested utility files in `plugins/kuadrant/src/utils/`
- Covers `validation.ts` (27 tests), `errors.ts` (11 tests), and `permissions.ts` (14 tests)
- All branches and edge cases covered per issue #336

## How to review
1. **Start with `validation.test.ts`** — pure functions, straightforward assertions, good warm-up
2. **Then `errors.test.ts`** — introduces the `mockResponse` helper for constructing mock `Response` objects
3. **Finally `permissions.test.ts`** — `canDeleteResource` is pure, `useKuadrantPermission` uses `renderHook` + `jest.mock`

## Test plan
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] `yarn backstage-cli package test --watchAll=false` — 30/30 suites pass, 346 tests pass, 0 failures

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for error handling across common and unknown HTTP statuses.
  * Added tests for permission checks, including ownership and resource-scoped permissions.
  * Added validation tests for Kubernetes names and HTTP/HTTPS URLs, including edge cases and invalid formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->