### PR TITLE
 feat: add APIKey expiration support to developer portal UI

### DIFF
--- a/plugins/kuadrant-backend/src/router.ts
+++ b/plugins/kuadrant-backend/src/router.ts
@@ -818,6 +818,7 @@ export async function createRouter({
     useCase: z.string().optional(),
     userEmail: z.string().optional(),
     secretName: z.string(), // frontend creates secret via POST /secrets first
+    expiresAt: z.string().datetime().optional(), // ISO 8601 expiry date set by consumer
   });
 
   router.post('/requests', async (req, res) => {
@@ -828,7 +829,7 @@ export async function createRouter({
 
     try {
       const credentials = await httpAuth.credentials(req);
-      const { apiProductName, namespace, planTier, useCase, userEmail, secretName: frontendSecretName } = parsed.data;
+      const { apiProductName, namespace, planTier, useCase, userEmail, secretName: frontendSecretName, expiresAt } = parsed.data;
 
       // extract userId from authenticated credentials, not from request body
       const { userEntityRef } = await getUserIdentity(req, httpAuth, userInfo);
@@ -885,6 +886,7 @@ export async function createRouter({
           planTier,
           useCase: useCase || '',
           requestedBy,
+          ...(expiresAt && { expiresAt }),
         },
       };
 
@@ -1455,6 +1457,7 @@ export async function createRouter({
       spec: z.object({
         useCase: z.string().optional(),
         planTier: z.string().optional(),
+        expiresAt: z.string().datetime().optional(),
       }).partial(),
     });
 

--- a/plugins/kuadrant-backend/src/router.ts
+++ b/plugins/kuadrant-backend/src/router.ts
@@ -818,7 +818,10 @@ export async function createRouter({
     useCase: z.string().optional(),
     userEmail: z.string().optional(),
     secretName: z.string(), // frontend creates secret via POST /secrets first
-    expiresAt: z.string().datetime().optional(), // ISO 8601 expiry date set by consumer
+    expiresAt: z.string().datetime().refine(
+      val => new Date(val) > new Date(),
+      { message: 'expiresAt must be in the future' },
+    ).optional(), // ISO 8601 expiry date set by consumer
   });
 
   router.post('/requests', async (req, res) => {
@@ -1457,7 +1460,10 @@ export async function createRouter({
       spec: z.object({
         useCase: z.string().optional(),
         planTier: z.string().optional(),
-        expiresAt: z.string().datetime().optional(),
+        expiresAt: z.string().datetime().refine(
+          val => new Date(val) > new Date(),
+          { message: 'expiresAt must be in the future' },
+        ).nullable().optional(),
       }).partial(),
     });
 

--- a/plugins/kuadrant/src/components/ApiKeyDetailPage/ApiKeyDetailPage.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyDetailPage/ApiKeyDetailPage.tsx
@@ -356,6 +356,27 @@ func main() {
                     </>
                   ) : null;
                 })()}
+
+                {apiKey.spec.expiresAt && (() => {
+                  const expiryDate = new Date(apiKey.spec.expiresAt!);
+                  const isExpired = phase === 'Expired';
+                  const daysLeft = Math.ceil((expiryDate.getTime() - Date.now()) / 86400000);
+                  return (
+                    <>
+                      <Typography variant="caption" className={classes.label}>
+                        Expires On
+                      </Typography>
+                      <Typography
+                        variant="body1"
+                        className={classes.value}
+                        style={isExpired ? { color: '#d32f2f' } : undefined}
+                      >
+                        {expiryDate.toLocaleDateString()}
+                        {isExpired ? ' (Expired)' : daysLeft > 0 ? ` (${daysLeft} days left)` : ''}
+                      </Typography>
+                    </>
+                  );
+                })()}
               </Box>
             </InfoCard>
           </Grid>

--- a/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
@@ -48,6 +48,7 @@ import {
   canDeleteResource,
 } from "../../utils/permissions";
 import { getAPIKeyPhase } from "../../utils/apikeys";
+import { getMyApiKeysStatusChipStyle } from "../../utils/styles";
 import { EditAPIKeyDialog } from "../EditAPIKeyDialog";
 import { ConfirmDeleteDialog } from "../ConfirmDeleteDialog";
 import { generateAuthCodeSnippets } from "../../utils/codeSnippets";
@@ -497,9 +498,10 @@ export const ApiKeyManagementTab = ({
   const pendingRequests = myRequests.filter(
     (r) => getAPIKeyPhase(r.status?.conditions) === "Pending",
   );
-  const approvedRequests = myRequests.filter(
-    (r) => getAPIKeyPhase(r.status?.conditions) === "Approved",
-  );
+  const approvedRequests = myRequests.filter((r) => {
+    const phase = getAPIKeyPhase(r.status?.conditions);
+    return phase === "Approved" || phase === "Expired";
+  });
   const rejectedRequests = myRequests.filter(
     (r) => getAPIKeyPhase(r.status?.conditions) === "Denied",
   );
@@ -532,7 +534,7 @@ export const ApiKeyManagementTab = ({
       render: (row: APIKey) => {
         const phase = getAPIKeyPhase(row.status?.conditions);
         if (phase === "Expired") {
-          return <Chip label="Expired" size="small" style={{ border: "none", backgroundColor: "#757575", color: "#fff" }} />;
+          return <Chip label="Expired" size="small" style={getMyApiKeysStatusChipStyle("Expired")} />;
         }
         if (!row.spec.expiresAt) {
           return <Typography variant="body2">-</Typography>;
@@ -541,7 +543,7 @@ export const ApiKeyManagementTab = ({
         const daysLeft = Math.ceil((expiryDate.getTime() - Date.now()) / 86400000);
         return (
           <Typography variant="body2">
-            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : ""}
+            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : " (Expired)"}
           </Typography>
         );
       },
@@ -733,7 +735,7 @@ export const ApiKeyManagementTab = ({
         const daysLeft = Math.ceil((expiryDate.getTime() - Date.now()) / 86400000);
         return (
           <Typography variant="body2">
-            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : ""}
+            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : " (Expired)"}
           </Typography>
         );
       },

--- a/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
+++ b/plugins/kuadrant/src/components/ApiKeyManagementTab/ApiKeyManagementTab.tsx
@@ -527,6 +527,26 @@ export const ApiKeyManagementTab = ({
       },
     },
     {
+      title: "Expires",
+      field: "spec.expiresAt",
+      render: (row: APIKey) => {
+        const phase = getAPIKeyPhase(row.status?.conditions);
+        if (phase === "Expired") {
+          return <Chip label="Expired" size="small" style={{ border: "none", backgroundColor: "#757575", color: "#fff" }} />;
+        }
+        if (!row.spec.expiresAt) {
+          return <Typography variant="body2">-</Typography>;
+        }
+        const expiryDate = new Date(row.spec.expiresAt);
+        const daysLeft = Math.ceil((expiryDate.getTime() - Date.now()) / 86400000);
+        return (
+          <Typography variant="body2">
+            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : ""}
+          </Typography>
+        );
+      },
+    },
+    {
       title: "API Key",
       field: "status.secretRef",
       searchable: false,
@@ -701,6 +721,22 @@ export const ApiKeyManagementTab = ({
             : "-"}
         </Typography>
       ),
+    },
+    {
+      title: "Expires",
+      field: "spec.expiresAt",
+      render: (row: APIKey) => {
+        if (!row.spec.expiresAt) {
+          return <Typography variant="body2">-</Typography>;
+        }
+        const expiryDate = new Date(row.spec.expiresAt);
+        const daysLeft = Math.ceil((expiryDate.getTime() - Date.now()) / 86400000);
+        return (
+          <Typography variant="body2">
+            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : ""}
+          </Typography>
+        );
+      },
     },
     {
       title: "Reviewed",

--- a/plugins/kuadrant/src/components/ApprovalQueueTable/ApprovalQueueTable.tsx
+++ b/plugins/kuadrant/src/components/ApprovalQueueTable/ApprovalQueueTable.tsx
@@ -550,7 +550,7 @@ export const ApprovalQueueTable = () => {
   const filterSections: FilterSection[] = useMemo(() => {
     if (!value?.allRequests) return [];
 
-    const statusCounts = { Approved: 0, Pending: 0, Denied: 0 };
+    const statusCounts = { Approved: 0, Pending: 0, Denied: 0, Expired: 0 };
     const apiProductCounts = new Map<string, number>();
     const tierCounts = new Map<string, number>();
 
@@ -574,16 +574,9 @@ export const ApprovalQueueTable = () => {
         title: "Status",
         options: [
           { value: "Pending", label: "Pending", count: statusCounts.Pending },
-          {
-            value: "Approved",
-            label: "Approved",
-            count: statusCounts.Approved,
-          },
-          {
-            value: "Denied",
-            label: "Denied",
-            count: statusCounts.Denied,
-          },
+          { value: "Approved", label: "Approved", count: statusCounts.Approved },
+          { value: "Denied", label: "Denied", count: statusCounts.Denied },
+          { value: "Expired", label: "Expired", count: statusCounts.Expired },
         ],
       },
       {
@@ -837,7 +830,7 @@ export const ApprovalQueueTable = () => {
         const daysLeft = Math.ceil((expiryDate.getTime() - Date.now()) / 86400000);
         return (
           <Typography variant="body2">
-            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : ""}
+            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : " (Expired)"}
           </Typography>
         );
       },

--- a/plugins/kuadrant/src/components/ApprovalQueueTable/ApprovalQueueTable.tsx
+++ b/plugins/kuadrant/src/components/ApprovalQueueTable/ApprovalQueueTable.tsx
@@ -159,7 +159,7 @@ const ApprovalDialog = ({
               </Typography>{" "}
               <Typography variant="body2" component="span">
                 {request.spec.expiresAt
-                  ? `${new Date(request.spec.expiresAt).toLocaleDateString()} (${Math.ceil((new Date(request.spec.expiresAt).getTime() - Date.now()) / 86400000)} days)`
+                  ? (() => { const daysLeft = Math.ceil((new Date(request.spec.expiresAt!).getTime() - Date.now()) / 86400000); return `${new Date(request.spec.expiresAt!).toLocaleDateString()} (${daysLeft <= 0 ? 'Expired' : `${daysLeft} days`})`; })()
                   : "No expiration"}
               </Typography>
             </Box>

--- a/plugins/kuadrant/src/components/ApprovalQueueTable/ApprovalQueueTable.tsx
+++ b/plugins/kuadrant/src/components/ApprovalQueueTable/ApprovalQueueTable.tsx
@@ -149,6 +149,20 @@ const ApprovalDialog = ({
                 {request.spec.useCase || "-"}
               </Typography>
             </Box>
+            <Box mb={2}>
+              <Typography
+                variant="body2"
+                component="span"
+                style={{ fontWeight: "bold" }}
+              >
+                Expires:
+              </Typography>{" "}
+              <Typography variant="body2" component="span">
+                {request.spec.expiresAt
+                  ? `${new Date(request.spec.expiresAt).toLocaleDateString()} (${Math.ceil((new Date(request.spec.expiresAt).getTime() - Date.now()) / 86400000)} days)`
+                  : "No expiration"}
+              </Typography>
+            </Box>
             {isReject && (
               <Box mt={2}>
                 <Typography variant="body2" color="textSecondary" gutterBottom>
@@ -811,6 +825,22 @@ export const ApprovalQueueTable = () => {
             : "-"}
         </Typography>
       ),
+    },
+    {
+      title: "Expires",
+      field: "spec.expiresAt",
+      render: (row) => {
+        if (!row.spec.expiresAt) {
+          return <Typography variant="body2" color="textSecondary">No expiration</Typography>;
+        }
+        const expiryDate = new Date(row.spec.expiresAt);
+        const daysLeft = Math.ceil((expiryDate.getTime() - Date.now()) / 86400000);
+        return (
+          <Typography variant="body2">
+            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : ""}
+          </Typography>
+        );
+      },
     },
     {
       title: "Reviewed By",

--- a/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
+++ b/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
@@ -18,6 +18,7 @@ import { useApi } from "@backstage/core-plugin-api";
 import { kuadrantApiRef } from '../../api';
 import { APIKey } from "../../types/api-management";
 import { formatPlanLimits } from '../../utils/policies';
+import { useDatePickerStyles } from '../../utils/styles';
 
 interface EditAPIKeyDialogProps {
   open: boolean;
@@ -38,6 +39,7 @@ export const EditAPIKeyDialog = ({
   request,
   availablePlans,
 }: EditAPIKeyDialogProps) => {
+  const classes = useDatePickerStyles();
   const kuadrantApi = useApi(kuadrantApiRef);
 
   const [planTier, setPlanTier] = useState("");
@@ -192,6 +194,7 @@ export const EditAPIKeyDialog = ({
             InputLabelProps={{ shrink: true }}
             disabled={saving}
             inputProps={{ min: new Date(Date.now() + 86400000).toISOString().split("T")[0] }}
+            className={classes.datePicker}
           />
         )}
       </DialogContent>

--- a/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
+++ b/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
@@ -19,7 +19,7 @@ import { kuadrantApiRef } from '../../api';
 import { APIKey } from "../../types/api-management";
 import { formatPlanLimits } from '../../utils/policies';
 import { useDatePickerStyles } from '../../utils/styles';
-import { isCustomDateInvalid } from '../../utils/apikeys';
+import { isCustomDateInvalid, customDateToISO } from '../../utils/apikeys';
 
 interface EditAPIKeyDialogProps {
   open: boolean;
@@ -76,8 +76,8 @@ export const EditAPIKeyDialog = ({
     setSaving(true);
 
     let expiresAt: string | undefined;
-    if (expiryDays === "custom" && customDate) {
-      expiresAt = new Date(customDate).toISOString();
+    if (expiryDays === 'custom' && customDate) {
+      expiresAt = customDateToISO(customDate);
     } else if (expiryDays) {
       expiresAt = new Date(Date.now() + parseInt(expiryDays, 10) * 86400000).toISOString();
     }
@@ -87,7 +87,8 @@ export const EditAPIKeyDialog = ({
         spec: {
           planTier,
           useCase: useCase.trim(),
-          expiresAt,
+          // null explicitly removes the field in Kubernetes JSON Merge Patch
+          expiresAt: expiryDays === '' ? null : expiresAt,
         },
       };
 

--- a/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
+++ b/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
@@ -42,6 +42,8 @@ export const EditAPIKeyDialog = ({
 
   const [planTier, setPlanTier] = useState("");
   const [useCase, setUseCase] = useState("");
+  const [expiryDays, setExpiryDays] = useState("");
+  const [customDate, setCustomDate] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
@@ -50,6 +52,14 @@ export const EditAPIKeyDialog = ({
       setPlanTier(request.spec.planTier || "");
       setUseCase(request.spec.useCase || "");
       setError("");
+      // initialise expiry from existing spec
+      if (request.spec.expiresAt) {
+        setExpiryDays("custom");
+        setCustomDate(request.spec.expiresAt.split("T")[0]);
+      } else {
+        setExpiryDays("");
+        setCustomDate("");
+      }
     }
   }, [open, request]);
 
@@ -62,11 +72,19 @@ export const EditAPIKeyDialog = ({
     setError("");
     setSaving(true);
 
+    let expiresAt: string | undefined;
+    if (expiryDays === "custom" && customDate) {
+      expiresAt = new Date(customDate).toISOString();
+    } else if (expiryDays) {
+      expiresAt = new Date(Date.now() + parseInt(expiryDays, 10) * 86400000).toISOString();
+    }
+
     try {
       const patch = {
         spec: {
           planTier,
           useCase: useCase.trim(),
+          expiresAt,
         },
       };
 
@@ -140,6 +158,42 @@ export const EditAPIKeyDialog = ({
           disabled={saving}
           helperText="Explain your intended use of this API for admin review"
         />
+
+        <FormControl fullWidth margin="normal" disabled={saving}>
+          <InputLabel id="edit-expiry-select-label">Expiration (optional)</InputLabel>
+          <Select
+            labelId="edit-expiry-select-label"
+            value={expiryDays}
+            onChange={(e) => {
+              setExpiryDays(e.target.value as string);
+              setCustomDate("");
+            }}
+          >
+            <MenuItem value="">No expiration</MenuItem>
+            {[7, 30, 60, 90].map(days => {
+              const date = new Date(Date.now() + days * 86400000);
+              return (
+                <MenuItem key={days} value={String(days)}>
+                  {days} days ({date.toLocaleDateString()})
+                </MenuItem>
+              );
+            })}
+            <MenuItem value="custom">Custom</MenuItem>
+          </Select>
+        </FormControl>
+        {expiryDays === "custom" && (
+          <TextField
+            label="Select date"
+            type="date"
+            fullWidth
+            margin="normal"
+            value={customDate}
+            onChange={(e) => setCustomDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            disabled={saving}
+            inputProps={{ min: new Date(Date.now() + 86400000).toISOString().split("T")[0] }}
+          />
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose} disabled={saving}>

--- a/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
+++ b/plugins/kuadrant/src/components/EditAPIKeyDialog/EditAPIKeyDialog.tsx
@@ -19,6 +19,7 @@ import { kuadrantApiRef } from '../../api';
 import { APIKey } from "../../types/api-management";
 import { formatPlanLimits } from '../../utils/policies';
 import { useDatePickerStyles } from '../../utils/styles';
+import { isCustomDateInvalid } from '../../utils/apikeys';
 
 interface EditAPIKeyDialogProps {
   open: boolean;
@@ -195,6 +196,8 @@ export const EditAPIKeyDialog = ({
             disabled={saving}
             inputProps={{ min: new Date(Date.now() + 86400000).toISOString().split("T")[0] }}
             className={classes.datePicker}
+            error={isCustomDateInvalid(expiryDays, customDate)}
+            helperText={isCustomDateInvalid(expiryDays, customDate) ? 'Expiration date must be in the future' : undefined}
           />
         )}
       </DialogContent>
@@ -206,7 +209,7 @@ export const EditAPIKeyDialog = ({
           onClick={handleSave}
           color="primary"
           variant="contained"
-          disabled={!planTier || saving}
+          disabled={!planTier || saving || isCustomDateInvalid(expiryDays, customDate)}
           startIcon={
             saving ? <CircularProgress size={16} color="inherit" /> : undefined
           }

--- a/plugins/kuadrant/src/components/MyApiKeysTable/MyApiKeysTable.tsx
+++ b/plugins/kuadrant/src/components/MyApiKeysTable/MyApiKeysTable.tsx
@@ -481,6 +481,26 @@ export const MyApiKeysTable = () => {
       },
     },
     {
+      title: "Expires",
+      field: "spec.expiresAt",
+      render: (row: APIKey) => {
+        const phase = getAPIKeyPhase(row.status?.conditions);
+        if (phase === "Expired") {
+          return <Chip label="Expired" size="small" style={{ border: "none", backgroundColor: "#757575", color: "#fff" }} />;
+        }
+        if (!row.spec.expiresAt) {
+          return <Typography variant="body2">-</Typography>;
+        }
+        const expiryDate = new Date(row.spec.expiresAt);
+        const daysLeft = Math.ceil((expiryDate.getTime() - Date.now()) / 86400000);
+        return (
+          <Typography variant="body2">
+            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : ""}
+          </Typography>
+        );
+      },
+    },
+    {
       title: "Actions",
       filtering: false,
       width: "100px",

--- a/plugins/kuadrant/src/components/MyApiKeysTable/MyApiKeysTable.tsx
+++ b/plugins/kuadrant/src/components/MyApiKeysTable/MyApiKeysTable.tsx
@@ -172,7 +172,7 @@ export const MyApiKeysTable = () => {
 
   // filter options from data
   const filterSections: FilterSection[] = useMemo(() => {
-    const statusCounts = { Approved: 0, Pending: 0, Denied: 0, Failed: 0 };
+    const statusCounts = { Approved: 0, Pending: 0, Denied: 0, Failed: 0, Expired: 0 };
     const apiProductCounts = new Map<string, number>();
     const tierCounts = new Map<string, number>();
 
@@ -197,12 +197,9 @@ export const MyApiKeysTable = () => {
         options: [
           { value: "Approved", label: "Active", count: statusCounts.Approved },
           { value: "Pending", label: "Pending", count: statusCounts.Pending },
-          {
-            value: "Denied",
-            label: "Denied",
-            count: statusCounts.Denied,
-          },
+          { value: "Denied", label: "Denied", count: statusCounts.Denied },
           { value: "Failed", label: "Failed", count: statusCounts.Failed },
+          { value: "Expired", label: "Expired", count: statusCounts.Expired },
         ],
       },
       {
@@ -486,7 +483,7 @@ export const MyApiKeysTable = () => {
       render: (row: APIKey) => {
         const phase = getAPIKeyPhase(row.status?.conditions);
         if (phase === "Expired") {
-          return <Chip label="Expired" size="small" style={{ border: "none", backgroundColor: "#757575", color: "#fff" }} />;
+          return <Chip label="Expired" size="small" style={getMyApiKeysStatusChipStyle("Expired")} />;
         }
         if (!row.spec.expiresAt) {
           return <Typography variant="body2">-</Typography>;
@@ -495,7 +492,7 @@ export const MyApiKeysTable = () => {
         const daysLeft = Math.ceil((expiryDate.getTime() - Date.now()) / 86400000);
         return (
           <Typography variant="body2">
-            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : ""}
+            {expiryDate.toLocaleDateString()}{daysLeft > 0 ? ` (${daysLeft}d)` : " (Expired)"}
           </Typography>
         );
       },

--- a/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
@@ -47,12 +47,16 @@ export const RequestAccessDialog = ({
 
   const [selectedPlan, setSelectedPlan] = useState('');
   const [useCase, setUseCase] = useState('');
+  const [expiryDays, setExpiryDays] = useState('');
+  const [customDate, setCustomDate] = useState('');
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 
   const handleClose = () => {
     setSelectedPlan('');
     setUseCase('');
+    setExpiryDays('');
+    setCustomDate('');
     setCreateError(null);
     onClose();
   };
@@ -74,6 +78,14 @@ export const RequestAccessDialog = ({
       // 2. create secret in consumer's namespace first (design doc: secret before APIKey)
       await kuadrantApi.createSecret(secretName, apiKeyValue);
 
+      // calculate expiresAt from selected preset or custom date
+      let expiresAt: string | undefined;
+      if (expiryDays === 'custom' && customDate) {
+        expiresAt = new Date(customDate).toISOString();
+      } else if (expiryDays) {
+        expiresAt = new Date(Date.now() + parseInt(expiryDays, 10) * 86400000).toISOString();
+      }
+
       try {
         // 3. create APIKey referencing the pre-existing secret
         await kuadrantApi.createRequest({
@@ -83,6 +95,7 @@ export const RequestAccessDialog = ({
           useCase: useCase.trim() || '',
           userEmail,
           secretName,
+          expiresAt,
         });
 
         alertApi.post({
@@ -93,6 +106,8 @@ export const RequestAccessDialog = ({
 
         setSelectedPlan('');
         setUseCase('');
+        setExpiryDays('');
+        setCustomDate('');
         onSuccess();
 
       } catch (apiKeyError) {
@@ -137,8 +152,7 @@ export const RequestAccessDialog = ({
             style={{ marginTop: 2 }}
           />
           <Typography variant="body2">
-            Your request will be reviewed by an API owner before access is
-            granted.
+            Your request will be reviewed by an API owner before access is granted.
           </Typography>
         </Box>
         {createError && (
@@ -192,6 +206,41 @@ export const RequestAccessDialog = ({
           helperText="Explain your intended use of this API for admin review"
           disabled={creating}
         />
+        <FormControl fullWidth margin="normal" disabled={creating}>
+          <InputLabel id="expiry-select-label">Expiration (optional)</InputLabel>
+          <Select
+            labelId="expiry-select-label"
+            value={expiryDays}
+            onChange={(e) => {
+              setExpiryDays(e.target.value as string);
+              setCustomDate('');
+            }}
+          >
+            <MenuItem value="">No expiration</MenuItem>
+            {[7, 30, 60, 90].map(days => {
+              const date = new Date(Date.now() + days * 86400000);
+              return (
+                <MenuItem key={days} value={String(days)}>
+                  {days} days ({date.toLocaleDateString()})
+                </MenuItem>
+              );
+            })}
+            <MenuItem value="custom">Custom</MenuItem>
+          </Select>
+        </FormControl>
+        {expiryDays === 'custom' && (
+          <TextField
+            label="Select date"
+            type="date"
+            fullWidth
+            margin="normal"
+            value={customDate}
+            onChange={(e) => setCustomDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            disabled={creating}
+            inputProps={{ min: new Date(Date.now() + 86400000).toISOString().split('T')[0] }}
+          />
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose} disabled={creating}>

--- a/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
@@ -23,7 +23,7 @@ import { kuadrantApiRef } from '../../api';
 import { Plan } from "../../types/api-management.ts";
 import { formatPlanLimits } from '../../utils/policies';
 import { useDatePickerStyles } from '../../utils/styles';
-import { isCustomDateInvalid } from '../../utils/apikeys';
+import { isCustomDateInvalid, customDateToISO } from '../../utils/apikeys';
 
 export interface RequestAccessDialogProps {
   open: boolean;
@@ -84,7 +84,7 @@ export const RequestAccessDialog = ({
       // calculate expiresAt from selected preset or custom date
       let expiresAt: string | undefined;
       if (expiryDays === 'custom' && customDate) {
-        expiresAt = new Date(customDate).toISOString();
+        expiresAt = customDateToISO(customDate);
       } else if (expiryDays) {
         expiresAt = new Date(Date.now() + parseInt(expiryDays, 10) * 86400000).toISOString();
       }

--- a/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
@@ -23,6 +23,7 @@ import { kuadrantApiRef } from '../../api';
 import { Plan } from "../../types/api-management.ts";
 import { formatPlanLimits } from '../../utils/policies';
 import { useDatePickerStyles } from '../../utils/styles';
+import { isCustomDateInvalid } from '../../utils/apikeys';
 
 export interface RequestAccessDialogProps {
   open: boolean;
@@ -242,6 +243,8 @@ export const RequestAccessDialog = ({
             disabled={creating}
             inputProps={{ min: new Date(Date.now() + 86400000).toISOString().split('T')[0] }}
             className={classes.datePicker}
+            error={isCustomDateInvalid(expiryDays, customDate)}
+            helperText={isCustomDateInvalid(expiryDays, customDate) ? 'Expiration date must be in the future' : undefined}
           />
         )}
       </DialogContent>
@@ -253,7 +256,7 @@ export const RequestAccessDialog = ({
           onClick={handleRequestAccess}
           color="primary"
           variant="contained"
-          disabled={!selectedPlan || creating}
+          disabled={!selectedPlan || creating || isCustomDateInvalid(expiryDays, customDate)}
           startIcon={
             creating ? (
               <CircularProgress size={16} color="inherit" />

--- a/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/RequestAccessDialog/RequestAccessDialog.tsx
@@ -22,6 +22,7 @@ import {
 import { kuadrantApiRef } from '../../api';
 import { Plan } from "../../types/api-management.ts";
 import { formatPlanLimits } from '../../utils/policies';
+import { useDatePickerStyles } from '../../utils/styles';
 
 export interface RequestAccessDialogProps {
   open: boolean;
@@ -42,6 +43,7 @@ export const RequestAccessDialog = ({
   userEmail,
   plans,
 }: RequestAccessDialogProps) => {
+  const classes = useDatePickerStyles();
   const kuadrantApi = useApi(kuadrantApiRef);
   const alertApi = useApi(alertApiRef);
 
@@ -239,6 +241,7 @@ export const RequestAccessDialog = ({
             InputLabelProps={{ shrink: true }}
             disabled={creating}
             inputProps={{ min: new Date(Date.now() + 86400000).toISOString().split('T')[0] }}
+            className={classes.datePicker}
           />
         )}
       </DialogContent>

--- a/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
@@ -25,7 +25,7 @@ import useAsync from 'react-use/lib/useAsync';
 import { kuadrantApiRef } from '../../api';
 import { formatPlanLimits } from '../../utils/policies';
 import { useDatePickerStyles } from '../../utils/styles';
-import { isCustomDateInvalid } from '../../utils/apikeys';
+import { isCustomDateInvalid, customDateToISO } from '../../utils/apikeys';
 
 export interface SimpleRequestAccessDialogProps {
   open: boolean;
@@ -137,7 +137,7 @@ export const SimpleRequestAccessDialog = ({
       // calculate expiresAt from selected preset or custom date
       let expiresAt: string | undefined;
       if (expiryDays === 'custom' && customDate) {
-        expiresAt = new Date(customDate).toISOString();
+        expiresAt = customDateToISO(customDate);
       } else if (expiryDays) {
         expiresAt = new Date(Date.now() + parseInt(expiryDays, 10) * 86400000).toISOString();
       }

--- a/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
@@ -25,6 +25,7 @@ import useAsync from 'react-use/lib/useAsync';
 import { kuadrantApiRef } from '../../api';
 import { formatPlanLimits } from '../../utils/policies';
 import { useDatePickerStyles } from '../../utils/styles';
+import { isCustomDateInvalid } from '../../utils/apikeys';
 
 export interface SimpleRequestAccessDialogProps {
   open: boolean;
@@ -356,6 +357,8 @@ export const SimpleRequestAccessDialog = ({
             disabled={creating}
             inputProps={{ min: new Date(Date.now() + 86400000).toISOString().split('T')[0] }}
             className={classes.datePicker}
+            error={isCustomDateInvalid(expiryDays, customDate)}
+            helperText={isCustomDateInvalid(expiryDays, customDate) ? 'Expiration date must be in the future' : undefined}
           />
         )}
       </DialogContent>
@@ -367,7 +370,7 @@ export const SimpleRequestAccessDialog = ({
           onClick={handleSubmit}
           color="primary"
           variant="contained"
-          disabled={!selectedApi || !selectedTier || creating}
+          disabled={!selectedApi || !selectedTier || creating || isCustomDateInvalid(expiryDays, customDate)}
           startIcon={
             creating ? (
               <CircularProgress size={16} color="inherit" />

--- a/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
@@ -62,6 +62,8 @@ export const SimpleRequestAccessDialog = ({
   const [selectedApi, setSelectedApi] = useState('');
   const [selectedTier, setSelectedTier] = useState('');
   const [useCase, setUseCase] = useState('');
+  const [expiryDays, setExpiryDays] = useState('');
+  const [customDate, setCustomDate] = useState('');
   const [creating, setCreating] = useState(false);
 
   // Fetch all published API products
@@ -105,6 +107,8 @@ export const SimpleRequestAccessDialog = ({
     setSelectedApi('');
     setSelectedTier('');
     setUseCase('');
+    setExpiryDays('');
+    setCustomDate('');
     onClose();
   };
 
@@ -127,6 +131,14 @@ export const SimpleRequestAccessDialog = ({
       // 2. create secret first (design doc: secret must exist before APIKey)
       await kuadrantApi.createSecret(secretName, apiKeyValue);
 
+      // calculate expiresAt from selected preset or custom date
+      let expiresAt: string | undefined;
+      if (expiryDays === 'custom' && customDate) {
+        expiresAt = new Date(customDate).toISOString();
+      } else if (expiryDays) {
+        expiresAt = new Date(Date.now() + parseInt(expiryDays, 10) * 86400000).toISOString();
+      }
+
       // 3. create APIKey referencing the pre-existing secret
       const response = await fetchApi.fetch(
         `${backendUrl}/api/kuadrant/requests`,
@@ -142,6 +154,7 @@ export const SimpleRequestAccessDialog = ({
             useCase: useCase.trim() || '',
             userEmail: userEmail || 'unknown',
             secretName,
+            expiresAt,
           }),
         },
       );
@@ -171,14 +184,11 @@ export const SimpleRequestAccessDialog = ({
         // Extract user-friendly error message
         const rawError = errorData.error || errorData.message || `Server returned ${response.status}`;
 
-        // Try to extract validation error details from Kubernetes error messages
-        // Example: "failed to create apikeys: APIKey.devportal.kuadrant.io "name" is invalid: spec.requestedBy.email: Invalid value: "admin": spec.requestedBy.email in body should match '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'"
         let errorMsg = rawError;
 
         if (rawError.includes('spec.requestedBy.email')) {
           errorMsg = 'Invalid email format. Please contact your administrator to update your profile email.';
         } else if (rawError.includes('is invalid:')) {
-          // Extract the validation message after "is invalid:"
           const match = rawError.match(/is invalid: (.+?)(?:\s+\(|$)/);
           if (match) {
             errorMsg = `Validation error: ${match[1]}`;
@@ -309,6 +319,42 @@ export const SimpleRequestAccessDialog = ({
           disabled={creating}
           inputProps={{ 'data-testid': 'usecase-input' }}
         />
+
+        <FormControl fullWidth margin="normal" disabled={creating}>
+          <InputLabel id="simple-expiry-select-label">Expiration (optional)</InputLabel>
+          <Select
+            labelId="simple-expiry-select-label"
+            value={expiryDays}
+            onChange={e => {
+              setExpiryDays(e.target.value as string);
+              setCustomDate('');
+            }}
+          >
+            <MenuItem value="">No expiration</MenuItem>
+            {[7, 30, 60, 90].map(days => {
+              const date = new Date(Date.now() + days * 86400000);
+              return (
+                <MenuItem key={days} value={String(days)}>
+                  {days} days ({date.toLocaleDateString()})
+                </MenuItem>
+              );
+            })}
+            <MenuItem value="custom">Custom</MenuItem>
+          </Select>
+        </FormControl>
+        {expiryDays === 'custom' && (
+          <TextField
+            label="Select date"
+            type="date"
+            fullWidth
+            margin="normal"
+            value={customDate}
+            onChange={e => setCustomDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            disabled={creating}
+            inputProps={{ min: new Date(Date.now() + 86400000).toISOString().split('T')[0] }}
+          />
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose} disabled={creating} data-testid="cancel-button">

--- a/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
+++ b/plugins/kuadrant/src/components/SimpleRequestAccessDialog/SimpleRequestAccessDialog.tsx
@@ -24,6 +24,7 @@ import {
 import useAsync from 'react-use/lib/useAsync';
 import { kuadrantApiRef } from '../../api';
 import { formatPlanLimits } from '../../utils/policies';
+import { useDatePickerStyles } from '../../utils/styles';
 
 export interface SimpleRequestAccessDialogProps {
   open: boolean;
@@ -52,6 +53,7 @@ export const SimpleRequestAccessDialog = ({
   onClose,
   onSuccess,
 }: SimpleRequestAccessDialogProps) => {
+  const classes = useDatePickerStyles();
   const config = useApi(configApiRef);
   const fetchApi = useApi(fetchApiRef);
   const alertApi = useApi(alertApiRef);
@@ -353,6 +355,7 @@ export const SimpleRequestAccessDialog = ({
             InputLabelProps={{ shrink: true }}
             disabled={creating}
             inputProps={{ min: new Date(Date.now() + 86400000).toISOString().split('T')[0] }}
+            className={classes.datePicker}
           />
         )}
       </DialogContent>

--- a/plugins/kuadrant/src/types/api-management.ts
+++ b/plugins/kuadrant/src/types/api-management.ts
@@ -45,6 +45,7 @@ export interface APIKeySpec {
   secretRef: {
     name: string;
   };
+  expiresAt?: string;
 }
 
 // Authorino v1beta3 Credentials types
@@ -127,6 +128,7 @@ export interface APIKeyRequest {
   useCase: string,
   userEmail: string,
   secretName?: string,
+  expiresAt?: string,
 }
 
 export interface APIProductSpec {

--- a/plugins/kuadrant/src/utils/apikeys.ts
+++ b/plugins/kuadrant/src/utils/apikeys.ts
@@ -1,13 +1,26 @@
 import { StatusCondition } from '../types/api-management';
 
 /**
- * Returns true if the custom date is invalid (in the past or empty).
+ * Parses a date picker value (YYYY-MM-DD) as local calendar date at end of day.
+ * Avoids UTC-parsing pitfalls where new Date("YYYY-MM-DD") is treated as UTC midnight.
+ */
+export function customDateToISO(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day, 23, 59, 59).toISOString();
+}
+
+/**
+ * Returns true if the custom date is invalid (in the past or today).
  * Only relevant when expiryDays === 'custom'.
  */
 export function isCustomDateInvalid(expiryDays: string, customDate: string): boolean {
   if (expiryDays !== 'custom') return false;
   if (!customDate) return true;
-  return new Date(customDate) <= new Date();
+  const [year, month, day] = customDate.split('-').map(Number);
+  const selected = new Date(year, month - 1, day);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return selected <= today;
 }
 
 /**

--- a/plugins/kuadrant/src/utils/apikeys.ts
+++ b/plugins/kuadrant/src/utils/apikeys.ts
@@ -5,6 +5,7 @@ import { StatusCondition } from '../types/api-management';
  *
  * Maps conditions to phases:
  * - Empty conditions array → Pending
+ * - Expired condition (status: True) → Expired
  * - Approved condition (status: True) → Approved
  * - Denied condition (status: True) → Denied
  * - Failed condition (status: True) → Failed
@@ -14,10 +15,15 @@ import { StatusCondition } from '../types/api-management';
  */
 export function getAPIKeyPhase(
   conditions?: StatusCondition[]
-): 'Pending' | 'Approved' | 'Denied' | 'Failed' {
+): 'Pending' | 'Approved' | 'Denied' | 'Failed' | 'Expired' {
   if (!conditions || conditions.length === 0) {
     return 'Pending';
   }
+
+  const expired = conditions.find(
+    c => c.type === 'Expired' && c.status === 'True'
+  );
+  if (expired) return 'Expired';
 
   const approved = conditions.find(
     c => c.type === 'Approved' && c.status === 'True'

--- a/plugins/kuadrant/src/utils/apikeys.ts
+++ b/plugins/kuadrant/src/utils/apikeys.ts
@@ -1,6 +1,16 @@
 import { StatusCondition } from '../types/api-management';
 
 /**
+ * Returns true if the custom date is invalid (in the past or empty).
+ * Only relevant when expiryDays === 'custom'.
+ */
+export function isCustomDateInvalid(expiryDays: string, customDate: string): boolean {
+  if (expiryDays !== 'custom') return false;
+  if (!customDate) return true;
+  return new Date(customDate) <= new Date();
+}
+
+/**
  * Derives the APIKey approval phase from Kubernetes conditions.
  *
  * Maps conditions to phases:

--- a/plugins/kuadrant/src/utils/styles.ts
+++ b/plugins/kuadrant/src/utils/styles.ts
@@ -1,4 +1,19 @@
 import { CSSProperties } from "react";
+import { makeStyles } from "@material-ui/core/styles";
+
+/**
+ * Shared hook for styling the native date picker calendar icon
+ * to be white and slightly larger — matches the dark theme of the dialogs.
+ */
+export const useDatePickerStyles = makeStyles(() => ({
+  datePicker: {
+    '& input[type="date"]::-webkit-calendar-picker-indicator': {
+      filter: 'invert(1)',
+      transform: 'scale(1.4)',
+      cursor: 'pointer',
+    },
+  },
+}));
 
 /**
  * Returns inline styles for API key status chips on the My API Keys page.

--- a/plugins/kuadrant/src/utils/styles.ts
+++ b/plugins/kuadrant/src/utils/styles.ts
@@ -10,6 +10,8 @@ export const getMyApiKeysStatusChipStyle = (phase: string): CSSProperties => {
       return { ...base, backgroundColor: "#1976d2", color: "#fff" }; // Blue
     case "Denied":
       return { ...base, backgroundColor: "#d32f2f", color: "#fff" }; // Red
+    case "Expired":
+      return { ...base, backgroundColor: "#757575", color: "#fff" }; // Grey
     case "Failed":
       return { ...base, backgroundColor: "#ed6c02", color: "#fff" }; // Orange
     case "Pending":
@@ -30,6 +32,8 @@ export const getApprovalQueueStatusChipStyle = (phase: string): CSSProperties =>
       return { ...base, backgroundColor: "#2e7d32", color: "#fff" }; // Green
     case "Denied":
       return { ...base, backgroundColor: "#d32f2f", color: "#fff" }; // Red
+    case "Expired":
+      return { ...base, backgroundColor: "#757575", color: "#fff" }; // Grey
     case "Pending":
       return { ...base, backgroundColor: "#ed6c02", color: "#fff" }; // Orange
     default:


### PR DESCRIPTION
 ---
 closes #346 
  Summary
  
  Adds expiration support to the Backstage developer portal UI. Consumers can now specify a desired expiration when requesting an API key. Expiration status and time remaining are displayed across all relevant
  views.

  Depends on: developer-portal-controller PR #74 (adds spec.expiresAt to APIKey and APIKeyRequest CRDs and Expired condition).

  ---
  Changes
  
  New utilities (plugins/kuadrant/src/utils/)

  - apikeys.ts — added Expired phase to getAPIKeyPhase(), added isCustomDateInvalid() validation helper
  - styles.ts — added Expired (grey #757575) to both chip style functions, added shared useDatePickerStyles hook for the date picker calendar icon

  Types (plugins/kuadrant/src/types/api-management.ts)

  - Added expiresAt?: string to APIKeySpec
  - Added expiresAt?: string to APIKeyRequest DTO

  Backend (plugins/kuadrant-backend/src/router.ts)

  - Added expiresAt: z.string().datetime().optional() to POST /requests Zod schema
  - Added expiresAt to the Kubernetes APIKey spec object on creation
  - Added expiresAt to PATCH /requests/:ns/:name schema to allow editing on pending keys

  Dialogs

  - RequestAccessDialog.tsx — expiration dropdown (No expiration / 7 / 30 / 60 / 90 days / Custom) with date picker when Custom selected, validation blocks submit if date is in the past
  - SimpleRequestAccessDialog.tsx — same expiration dropdown
  - EditAPIKeyDialog.tsx — same dropdown, initialised from existing spec.expiresAt

  Tables & views

  - MyApiKeysTable.tsx — new "Expires" column showing date + days remaining, or grey "Expired" chip
  - ApiKeyManagementTab.tsx — "Expires" column in both Pending Requests and Approved API Keys tables
  - ApprovalQueueTable.tsx — "Expires" column + expiration shown in Approve/Reject confirmation dialog so owners can see requested duration before deciding
  - ApiKeyDetailPage.tsx — "Expires On" field in the API Key Details card

  ---
  How to verify
  
  Prerequisites

  - Kind cluster running (cd kuadrant-dev-setup && make kind-create)
  - Updated CRDs installed (cd developer-portal-controller && kubectl config use-context kind-local-cluster && make install)
  - Controller running locally (cd developer-portal-controller && make run)
  - App running (yarn dev)

  Steps

  1. Request a key with expiration
  - Log in as consumer1
  - Go to any API product → "API Keys" tab → "Request API Access"
  - Select a tier, optionally a use case
  - Select "30 days" from the Expiration dropdown
  - Click Submit — request should be created

  2. Verify expiration shows in UI
  - Go to http://localhost:3000/kuadrant/my-api-keys
  - New key should show status "Pending" and "Expires" column with date
  
  3. Approve the key
  - Log in as owner1 or admin
  - Go to the same API product → "API Keys" tab
  - In Pending Requests table — click the actions menu → Approve
  - Approve dialog should show the requested expiration

  4. Verify Approved state
  - Log back in as consumer1
  - Key should now show "Active" status with expiration date and days remaining

  5. Test Custom date validation
  - Open "Request API Access" dialog
  - Select "Custom" from Expiration dropdown
  - Enter a past date — field should turn red with error message and Submit button should be disabled

  6. Test Expired state (requires controller running)
  - Request a key, approve it
  - Wait for expiration or set a very short expiry via kubectl patch
  - Key should show grey "Expired" chip in all tables
  - Enforcement secret should be deleted from Kuadrant namespace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API key requests and “request access” flows now support an optional expiration date (preset durations or a custom date).
  - You can edit an existing API key’s expiration, including setting it back to “no expiration”.
  - Expiration information is now shown across API key detail views, management tables, and approval queues, with an “Expires” column and updated status filtering for expired keys.
- **Bug Fixes**
  - Expiration inputs are validated to ensure custom dates aren’t empty or set to today/past, and that expiry must be a future ISO date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->