### PR TITLE
chore: pin GitHub Actions to commit SHAs using ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: "22"
 
@@ -56,10 +56,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: "22"
 
@@ -85,10 +85,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: "22"
 
@@ -109,10 +109,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: "22"
 
@@ -137,7 +137,7 @@ jobs:
         run: git clone https://github.com/Kuadrant/developer-portal-controller.git ../developer-portal-controller
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # ratchet:helm/kind-action@v1
         with:
           cluster_name: kuadrant-test
           wait: 60s
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: playwright-report
           path: e2e-tests/playwright-report/
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload test videos
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: playwright-videos
           path: e2e-tests/test-results/

--- a/.github/workflows/contributor-governance.yml
+++ b/.github/workflows/contributor-governance.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   governance:
-    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@main
+    uses: Kuadrant/.github/.github/workflows/contributor-governance.yml@dfca825e8d83b5409099103b1bfcd9036867412d # ratchet:Kuadrant/.github/.github/workflows/contributor-governance.yml@main
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
  - Pin all GitHub Action references to commit SHAs using [ratchet](https://github.com/sethvargo/ratchet)

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2055

## Motivation
Tags are mutable — action maintainers can force-push them, silently changing the code our CI runs. Pinning to commit SHAs makes each reference immutable, mitigating supply-chain attacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to verify that workflow actions remain securely pinned to immutable revisions.

* **Security**
  * Improved the reliability and security of continuous integration, publishing, and governance workflows by pinning actions to fixed revisions.
  * Reduced the risk of unexpected workflow changes from moving references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->