### PR TITLE
ci: run e2e on oinc instead of kind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,15 @@ jobs:
       - name: Run unit tests
         run: yarn test
 
+  # CI e2e cluster is oinc (same addons as `yarn oinc:cluster` / kuadrant-console-plugin),
+  # not kind. Copied from kuadrant-console-plugin `.github/workflows/e2e-common.yaml`:
+  # ubuntu-latest (no larger runner), 60m timeout, oinc v0.4.3 from GitHub releases,
+  # Helm, Docker on the hosted runner (no extra DinD/privileged job). oinc create is
+  # nested k8s (~6+ min; Istio + Kuadrant + MCP Gateway). Kind stays local loop 1;
+  # unit tests do not need a cluster.
   e2e-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -128,6 +135,18 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
+
+      - name: Install oinc
+        run: |
+          OINC_VERSION="${OINC_VERSION:-v0.4.3}"
+          curl -fL -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
+          chmod +x oinc
+          file oinc | grep -q ELF || { echo "downloaded file is not a valid binary"; exit 1; }
+          ./oinc version
+          sudo mv oinc /usr/local/bin/
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # ratchet:azure/setup-helm@v4
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -142,31 +161,36 @@ jobs:
           cd e2e-tests
           yarn playwright install --with-deps chromium
 
-      # TEMPORARY: clone controller until it's published to a registry
-      - name: Clone developer-portal-controller
-        run: git clone https://github.com/Kuadrant/developer-portal-controller.git ../developer-portal-controller
+      - name: Create oinc cluster
+        run: yarn oinc:cluster
 
-      - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # ratchet:helm/kind-action@v1
-        with:
-          cluster_name: kuadrant-test
-          wait: 60s
-
-      - name: Setup RBAC and Kuadrant on kind cluster
+      - name: Verify Kuadrant and MCP Gateway
         run: |
-          cd kuadrant-dev-setup
-          kubectl apply -f rbac/rhdh-rbac.yaml
-          ./scripts/kube-env-setup.sh
-          make kuadrant-install CLUSTER_NAME=kuadrant-test
-          make demo-install
-          cd ..
+          kubectl config current-context
+          test "$(kubectl config current-context)" = oinc
+          kubectl get crd mcpserverregistrations.mcp.kuadrant.io
+          kubectl api-resources --api-group=mcp.kuadrant.io
+          kubectl -n kuadrant-system wait --timeout=180s --for=condition=Available deployment/developer-portal-controller
+          oinc status || true
 
       - name: Start Backstage
         run: |
-          yarn dev:kind &
+          yarn dev:oinc &
           echo $! > backstage.pid
-          # wait for backstage to be ready (webpack dev server)
-          timeout 120 bash -c 'until curl -f http://localhost:3000 > /dev/null 2>&1; do sleep 2; done'
+          DEV_PID=$(cat backstage.pid)
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:3000 >/dev/null 2>&1; then
+              echo "yarn-dev ready on :3000"
+              exit 0
+            fi
+            if ! kill -0 "$DEV_PID" 2>/dev/null; then
+              echo "yarn-dev process died unexpectedly"
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "yarn-dev not ready after 180s"
+          exit 1
 
       - name: Run e2e tests
         run: |
@@ -189,9 +213,21 @@ jobs:
           path: e2e-tests/test-results/
           retention-days: 7
 
+      - name: Dump cluster diagnostics
+        if: failure()
+        run: |
+          kubectl get pods -A || true
+          kubectl get crd | grep -E 'kuadrant|mcp' || true
+          kubectl -n kuadrant-system get deploy,pods || true
+          kubectl get mcpserverregistrations -A || true
+
       - name: Stop Backstage
         if: always()
         run: |
           if [ -f backstage.pid ]; then
             kill $(cat backstage.pid) || true
           fi
+
+      - name: Teardown oinc
+        if: always()
+        run: yarn oinc:teardown || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,10 +158,14 @@ jobs:
           cd e2e-tests
           yarn install --immutable
 
+      # Skip --with-deps: it runs apt-get update, which hung ~56m on
+      # azure.archive.ubuntu.com (Ign mirrors) and exhausted the 60m job.
+      # e2e-tests postinstall already fetches Chromium; ubuntu-latest ships
+      # Chrome and the shared libs Playwright needs.
       - name: Install Playwright browsers
         run: |
           cd e2e-tests
-          yarn playwright install --with-deps chromium
+          yarn playwright install chromium
 
       - name: Create oinc cluster
         run: yarn oinc:cluster

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,14 +136,16 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      # Download to /tmp: this repo has an oinc/ directory, so curl -o oinc fails
+      # with "Is a directory" (console-plugin does not have that path).
       - name: Install oinc
         run: |
           OINC_VERSION="${OINC_VERSION:-v0.4.3}"
-          curl -fL -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
-          chmod +x oinc
-          file oinc | grep -q ELF || { echo "downloaded file is not a valid binary"; exit 1; }
-          ./oinc version
-          sudo mv oinc /usr/local/bin/
+          curl -fL -o /tmp/oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
+          chmod +x /tmp/oinc
+          file /tmp/oinc | grep -q ELF || { echo "downloaded file is not a valid binary"; exit 1; }
+          /tmp/oinc version
+          sudo mv /tmp/oinc /usr/local/bin/oinc
 
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # ratchet:azure/setup-helm@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,9 +104,9 @@ yarn test --filter=backend      # run tests for specific package
 
 **E2E Tests:**
 
-Prerequisites:
-1. Kind cluster running with Kuadrant (`cd kuadrant-dev-setup && make kind-create`)
-2. App running (`yarn dev` in separate terminal)
+CI uses oinc, not kind. Prerequisites:
+1. oinc cluster with Kuadrant + MCP Gateway (`yarn oinc:cluster`)
+2. App running (`yarn dev:oinc` in a separate terminal)
 
 ```bash
 cd e2e-tests

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ yarn test --filter=backend      # run tests for specific package
 
 End-to-end tests use Playwright to test the Kuadrant plugin UI and workflows.
 
-Prerequisites:
-1. Kind cluster running with Kuadrant (`cd kuadrant-dev-setup && make kind-create`)
-2. App running (`yarn dev` in separate terminal)
+Prerequisites (CI uses oinc, not kind):
+1. Cluster: `yarn oinc:cluster` **or** `make -C kuadrant-dev-setup kind-create`
+2. App: `yarn dev:oinc` **or** `yarn dev:kind` (separate terminal)
 
 Run tests:
 ```bash

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -101,7 +101,7 @@ The `e2e-tests` job matches local loop 2 (`yarn oinc:cluster` then `yarn dev:oin
 | Host app | `yarn dev:oinc` (Dex :3000) | `yarn dev:kind` |
 | Job timeout | 60 minutes (oinc create is ~6+ min; Istio + Kuadrant + MCP Gateway) | n/a in CI |
 
-oinc is installed the same way as console-plugin: download `oinc-linux-amd64` from the [oinc v0.4.3](https://github.com/jasonmadigan/oinc/releases/tag/v0.4.3) GitHub release, `file` check, `oinc version`, move to `/usr/local/bin`. Helm is installed with `azure/setup-helm`. There is no extra Docker-in-Docker or privileged job; nested k8s uses the runner’s Docker, as in console-plugin. Kind is **not** used in CI e2e. It remains the lighter local fallback (loop 1). Unit tests do not start a cluster.
+oinc is installed like console-plugin, except the binary is downloaded to `/tmp` first: this repo has an `oinc/` directory, so `curl -o oinc` fails with “Is a directory”. Source is `oinc-linux-amd64` from the [oinc v0.4.3](https://github.com/jasonmadigan/oinc/releases/tag/v0.4.3) GitHub release, then `file` check, `oinc version`, and `mv` to `/usr/local/bin`. Helm is installed with `azure/setup-helm`. There is no extra Docker-in-Docker or privileged job; nested k8s uses the runner’s Docker, as in console-plugin. Kind is **not** used in CI e2e. It remains the lighter local fallback (loop 1). Unit tests do not start a cluster.
 
 ## npm Trusted Publishing
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -80,14 +80,28 @@ before publication. Without this step, the frontend would be missing
 
 ## CI Pipeline
 
-`ci.yml` runs four parallel jobs:
+`ci.yml` runs five parallel jobs:
 
 - **build-validate**: Lint, prettier, type-check, build, verify output bundles exist
+- **shellcheck**: Shell scripts under `scripts/`, `oinc/`, and `kuadrant-dev-setup/scripts/`
 - **export-plugins**: Build and verify the frontend and backend dynamic exports
-- **unittests**: Backend and frontend unit tests
-- **e2e-tests**: Spins up a kind cluster with Kuadrant, starts Backstage, runs Playwright tests
+- **unittests**: Backend and frontend unit tests (no Kubernetes cluster)
+- **e2e-tests**: oinc cluster with Kuadrant + MCP Gateway, host `yarn dev:oinc`, Playwright
 
 E2e test artifacts (Playwright report, videos on failure) are uploaded and retained for 7 days.
+
+### E2E cluster (oinc, not kind)
+
+The `e2e-tests` job matches local loop 2 (`yarn oinc:cluster` then `yarn dev:oinc`) and the [kuadrant-console-plugin](https://github.com/Kuadrant/kuadrant-console-plugin) GitHub Actions pattern:
+
+| | CI e2e | Local loop 1 (kind) |
+|---|---|---|
+| Cluster | oinc (`ubuntu-latest`, Docker on the hosted runner) | `make -C kuadrant-dev-setup kind-create` |
+| Addons | gateway-api, cert-manager, metallb, istio, kuadrant@latest, mcp-gateway | Kuadrant via `make kuadrant-install` (no MCP Gateway operator) |
+| Host app | `yarn dev:oinc` (Dex :3000) | `yarn dev:kind` |
+| Job timeout | 60 minutes (oinc create is ~6+ min; Istio + Kuadrant + MCP Gateway) | n/a in CI |
+
+oinc is installed the same way as console-plugin: download `oinc-linux-amd64` from the [oinc v0.4.3](https://github.com/jasonmadigan/oinc/releases/tag/v0.4.3) GitHub release, `file` check, `oinc version`, move to `/usr/local/bin`. Helm is installed with `azure/setup-helm`. There is no extra Docker-in-Docker or privileged job; nested k8s uses the runner’s Docker, as in console-plugin. Kind is **not** used in CI e2e. It remains the lighter local fallback (loop 1). Unit tests do not start a cluster.
 
 ## npm Trusted Publishing
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -88,7 +88,7 @@ before publication. Without this step, the frontend would be missing
 - **unittests**: Backend and frontend unit tests (no Kubernetes cluster)
 - **e2e-tests**: oinc cluster with Kuadrant + MCP Gateway, host `yarn dev:oinc`, Playwright
 
-E2e test artifacts (Playwright report, videos on failure) are uploaded and retained for 7 days.
+E2e test artifacts (Playwright report, videos on failure) are uploaded and retained for 7 days. Playwright browsers are installed without `--with-deps`: that flag runs `apt-get update`, which has hung for nearly an hour on GitHub-hosted Azure Ubuntu mirrors and leaves no time for `yarn oinc:cluster`. Chromium is already fetched by `e2e-tests` postinstall; `ubuntu-latest` provides the system libraries.
 
 ### E2E cluster (oinc, not kind)
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -27,9 +27,12 @@ e2e-tests/
 
 ## Running Tests
 
-Prerequisites:
-1. Kind cluster running: `cd kuadrant-dev-setup && make kind-create`
-2. App running: `yarn dev` (in separate terminal)
+CI (`e2e-tests` in `.github/workflows/ci.yml`) uses **oinc**, not kind: `yarn oinc:cluster` then `yarn dev:oinc`, same addons as [kuadrant-console-plugin](https://github.com/Kuadrant/kuadrant-console-plugin) (gateway-api, cert-manager, metallb, istio, kuadrant, mcp-gateway). That job is 60 minutes on `ubuntu-latest` because oinc create is ~6+ min. See [docs/ci.md](ci.md).
+
+Locally, match CI (loop 2) or use kind (loop 1):
+
+1. Cluster: `yarn oinc:cluster` (CI path) **or** `make -C kuadrant-dev-setup kind-create`
+2. App: `yarn dev:oinc` **or** `yarn dev:kind` (in a separate terminal)
 
 ```bash
 cd e2e-tests
@@ -37,6 +40,8 @@ yarn test                              # all kuadrant tests
 yarn test --grep "Happy Path"          # specific test suite
 yarn test --grep "permissions matrix"  # RBAC tests only
 ```
+
+Kind has no MCP Gateway operator. Prefer oinc when exercising MCP. Do not run kind and oinc at the same time (both write `.env`).
 
 ## Key Principles
 

--- a/docs/oinc.md
+++ b/docs/oinc.md
@@ -140,15 +140,18 @@ Yarn-dev (loops 1–2) imports the plugins in-tree with hot reload. It never loa
 
 ## Running e2e tests against oinc
 
-Loop 3, with RHDH running and port-forwarded:
+CI Playwright (`e2e-tests` in `.github/workflows/ci.yml`) is **loop 2**: oinc cluster + host `yarn dev:oinc` on :3000. Locally:
+
+```bash
+yarn oinc:cluster
+yarn dev:oinc   # separate terminal
+cd e2e-tests && yarn test
+```
+
+Loop 3 (in-cluster RHDH, Guest on :7007) is optional and is **not** what CI runs:
 
 ```bash
 kubectl port-forward svc/rhdh-developer-hub 7007:7007 -n rhdh
-```
-
-Run the e2e tests with `BASE_URL` pointed at port 7007 (the default is 3000 for `yarn dev:oinc` / `yarn dev:kind`):
-
-```bash
 cd e2e-tests
 BASE_URL=http://localhost:7007 yarn test
 ```

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -4,10 +4,10 @@ End-to-end tests for the Kuadrant Backstage plugins using Playwright.
 
 ## Running Tests
 
-Start the app in another terminal:
+Start the app in another terminal (after the cluster below):
 
 ```bash
-yarn dev
+yarn dev:oinc
 ```
 
 Then run the tests:
@@ -25,11 +25,17 @@ yarn test:smoke
 
 ## Prerequisites
 
-- Kind cluster running with Kuadrant:
-  ```bash
-  cd kuadrant-dev-setup
-  make kind-create
-  ```
+CI uses oinc (Kuadrant + MCP Gateway), not kind. Locally, match that or use kind as a lighter fallback:
+
+```bash
+# loop 2 — same cluster as CI
+yarn oinc:cluster
+yarn dev:oinc
+
+# loop 1 — kind, no MCP Gateway operator
+make -C kuadrant-dev-setup kind-create
+yarn dev:kind
+```
 
 ## What's Tested
 

--- a/e2e-tests/playwright/e2e/kuadrant-request-access.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-request-access.spec.ts
@@ -1,6 +1,35 @@
-import { test, expect } from "@playwright/test";
+import {
+  test,
+  expect,
+  type Page,
+  type Locator,
+  type Route,
+} from "@playwright/test";
 import { Common } from "../utils/common";
-import { TIMEOUTS, waitForApiKeysPageReady } from "../utils/kuadrant-helpers";
+import {
+  TIMEOUTS,
+  waitForApiKeysPageReady,
+  openMuiSelect,
+  chooseMuiSelectOption,
+} from "../utils/kuadrant-helpers";
+
+async function selectApiAndTier(page: Page, dialog: Locator): Promise<void> {
+  await chooseMuiSelectOption(page, dialog.getByTestId("api-select"));
+  await chooseMuiSelectOption(page, dialog.getByTestId("tier-select"));
+}
+
+async function interceptCreateRequest(
+  page: Page,
+  handler: (route: Route) => Promise<void>,
+): Promise<void> {
+  await page.route("**/api/kuadrant/requests", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    await handler(route);
+  });
+}
 
 /**
  * E2E tests for SimpleRequestAccessDialog
@@ -73,20 +102,9 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
       timeout: TIMEOUTS.DEFAULT,
     });
 
-    // click to open dropdown
-    await apiSelect.click();
-
-    // verify dropdown shows published APIs (like toystore-api)
-    const listbox = page.getByRole("listbox");
-    await expect(listbox, "API dropdown should open").toBeVisible({
-      timeout: TIMEOUTS.DEFAULT,
-    });
-
-    // should have at least one API option
-    const apiOptions = listbox.getByRole("option");
-    const firstOption = apiOptions.first();
+    const listbox = await openMuiSelect(page, apiSelect);
     await expect(
-      firstOption,
+      listbox.getByRole("option").first(),
       "At least one API should be available",
     ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
   });
@@ -107,17 +125,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
 
     // select an API (toystore-api should have plans)
     const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-
-    const listbox = page.getByRole("listbox");
-    const toystoreOption = listbox
-      .getByRole("option", { name: /toystore/i })
-      .first();
-    await expect(
-      toystoreOption,
-      "Toystore API should be in the list",
-    ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
-    await toystoreOption.click();
+    await chooseMuiSelectOption(page, apiSelect, /toystore/i);
 
     // verify tiers dropdown becomes enabled and populated
     const tierSelect = dialog.getByTestId("tier-select");
@@ -129,14 +137,9 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
       "Tiers dropdown should be enabled after API selection",
     ).toBeEnabled({ timeout: TIMEOUTS.DEFAULT });
 
-    // click tiers dropdown
-    await tierSelect.click();
-
-    // verify tiers are populated
-    const tierListbox = page.getByRole("listbox");
-    const tierOption = tierListbox.getByRole("option").first();
+    const tierListbox = await openMuiSelect(page, tierSelect);
     await expect(
-      tierOption,
+      tierListbox.getByRole("option").first(),
       "At least one tier should be available",
     ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
   });
@@ -153,21 +156,11 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
-    // select toystore-api
     const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    const listbox = page.getByRole("listbox");
-    const toystoreOption = listbox
-      .getByRole("option", { name: /toystore/i })
-      .first();
-    await toystoreOption.click();
+    await chooseMuiSelectOption(page, apiSelect, /toystore/i);
 
-    // open tiers dropdown
     const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-
-    // verify tier options show limits (e.g., "bronze (10 per minute)")
-    const tierListbox = page.getByRole("listbox");
+    const tierListbox = await openMuiSelect(page, tierSelect);
     const tierWithLimits = tierListbox.getByRole("option").first();
     const tierText = tierWithLimits;
 
@@ -200,12 +193,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
       "Submit button should be disabled initially",
     ).toBeDisabled({ timeout: TIMEOUTS.DEFAULT });
 
-    // select API
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    const apiListbox = page.getByRole("listbox");
-    const apiOption = apiListbox.getByRole("option").first();
-    await apiOption.click();
+    await chooseMuiSelectOption(page, dialog.getByTestId("api-select"));
 
     // submit should still be disabled (no tier selected)
     await expect(
@@ -213,12 +201,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
       "Submit button should be disabled without tier",
     ).toBeDisabled({ timeout: TIMEOUTS.DEFAULT });
 
-    // select tier
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    const tierListbox = page.getByRole("listbox");
-    const tierOption = tierListbox.getByRole("option").first();
-    await tierOption.click();
+    await chooseMuiSelectOption(page, dialog.getByTestId("tier-select"));
 
     // submit should now be enabled
     await expect(
@@ -268,19 +251,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
-    // select API
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    const apiOption = listbox.getByRole("option").first();
-    await apiOption.click();
-
-    // select tier
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    const tierOption = listbox.getByRole("option").first();
-    await tierOption.click();
+    await selectApiAndTier(page, dialog);
 
     // fill use case
     const useCaseField = dialog.getByTestId("usecase-input");
@@ -313,19 +284,9 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
-    // select API and tier
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await selectApiAndTier(page, dialog);
 
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
-
-    // intercept the request to slow it down
-    await page.route("**/api/kuadrant/requests", async (route) => {
+    await interceptCreateRequest(page, async (route) => {
       await new Promise((resolve) => setTimeout(resolve, 1000));
       await route.continue();
     });
@@ -358,11 +319,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
-    // select API
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    const listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await chooseMuiSelectOption(page, dialog.getByTestId("api-select"));
 
     // fill use case
     const useCaseField = dialog.getByTestId("usecase-input");
@@ -408,11 +365,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
       "API field should have helper text",
     ).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
-    // verify Tiers field helper text appears after selecting API
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    const listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await chooseMuiSelectOption(page, dialog.getByTestId("api-select"));
 
     const tierHelperText = dialog.getByText(
       /select an api to view available tiers/i,
@@ -435,8 +388,9 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
-    // intercept the request to simulate a server error
-    await page.route("**/api/kuadrant/requests", async (route) => {
+    await selectApiAndTier(page, dialog);
+
+    await interceptCreateRequest(page, async (route) => {
       await route.fulfill({
         status: 500,
         contentType: "application/json",
@@ -445,17 +399,6 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
         }),
       });
     });
-
-    // select API and tier
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
-
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
 
     // submit
     const submitButton = dialog.getByTestId("submit-button");
@@ -485,8 +428,9 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
-    // intercept request to simulate email validation error
-    await page.route("**/api/kuadrant/requests", async (route) => {
+    await selectApiAndTier(page, dialog);
+
+    await interceptCreateRequest(page, async (route) => {
       await route.fulfill({
         status: 500,
         contentType: "application/json",
@@ -496,17 +440,6 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
         }),
       });
     });
-
-    // select API and tier
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
-
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
 
     // submit
     const submitButton = dialog.getByTestId("submit-button");
@@ -543,16 +476,7 @@ test.describe("Request Access Dialog - My API Keys Page", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.DEFAULT });
 
-    // select API and tier
-    const apiSelect = dialog.getByTestId("api-select");
-    await apiSelect.click();
-    let listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
-
-    const tierSelect = dialog.getByTestId("tier-select");
-    await tierSelect.click();
-    listbox = page.getByRole("listbox");
-    await listbox.getByRole("option").first().click();
+    await selectApiAndTier(page, dialog);
 
     // submit
     const submitButton = dialog.getByTestId("submit-button");

--- a/e2e-tests/playwright/utils/kuadrant-helpers.ts
+++ b/e2e-tests/playwright/utils/kuadrant-helpers.ts
@@ -162,6 +162,42 @@ export async function waitForApiKeysPageReady(
   }).toPass({ timeout: TIMEOUTS.VERY_SLOW, intervals: [500, 1000, 2000] });
 }
 
+/** Open a MUI Select via its listbox button (testid click misses the menu in CI). */
+export async function openMuiSelect(
+  page: Page,
+  select: Locator,
+): Promise<Locator> {
+  const trigger = select.getByRole("button").or(select);
+  await expect(trigger).toBeEnabled({ timeout: TIMEOUTS.SLOW });
+
+  await expect(async () => {
+    const listbox = page.getByRole("listbox");
+    if (await listbox.isVisible()) {
+      return;
+    }
+    await trigger.click();
+    await expect(listbox).toBeVisible({ timeout: 2000 });
+  }).toPass({ timeout: TIMEOUTS.SLOW, intervals: [300, 500, 1000] });
+
+  return page.getByRole("listbox");
+}
+
+export async function chooseMuiSelectOption(
+  page: Page,
+  select: Locator,
+  option?: string | RegExp,
+): Promise<void> {
+  const listbox = await openMuiSelect(page, select);
+  const opt = option
+    ? listbox.getByRole("option", { name: option }).first()
+    : listbox.getByRole("option").first();
+  await expect(opt, "Select should have at least one option").toBeVisible({
+    timeout: TIMEOUTS.DEFAULT,
+  });
+  await opt.click();
+  await expect(listbox).toBeHidden({ timeout: TIMEOUTS.DEFAULT });
+}
+
 /**
  * Retry an operation with delays for kubernetes propagation.
  */

--- a/e2e-tests/playwright/utils/kuadrant-helpers.ts
+++ b/e2e-tests/playwright/utils/kuadrant-helpers.ts
@@ -167,7 +167,7 @@ export async function openMuiSelect(
   page: Page,
   select: Locator,
 ): Promise<Locator> {
-  const trigger = select.getByRole("button").or(select);
+  const trigger = select.getByRole("button");
   await expect(trigger).toBeEnabled({ timeout: TIMEOUTS.SLOW });
 
   await expect(async () => {


### PR DESCRIPTION
## Summary
Closes #378.

- CI `e2e-tests` (`ci.yml`) now provisions oinc (`yarn oinc:cluster`) instead of kind (`helm/kind-action` + `make kuadrant-install`).
- Host app is `yarn dev:oinc` (Dex on :3000), matching local loop 2 and what Playwright already hits.
- Cluster create is the console-plugin stack: oinc v0.4.3 from GitHub releases, Helm, `--addons gateway-api,cert-manager,metallb,istio,kuadrant@latest,mcp-gateway --metallb-address-pool auto`, class-less Gateway (not `--gateway-api-gateway`). MCP comes from the real mcp-gateway addon, not kind custom env.
- Job timeout is 60 minutes on `ubuntu-latest` (same runner as kuadrant-console-plugin; oinc create is ~6+ min). Unit tests stay clusterless. Kind remains local loop 1 only.

## How to review
1. `.github/workflows/ci.yml` job `e2e-tests` — compare with `kuadrant-console-plugin/.github/workflows/e2e-common.yaml` (oinc install + timeout + runner).
2. `oinc/setup-cluster.sh` is unchanged; CI just calls `yarn oinc:cluster`.
3. Docs: `docs/ci.md`, `docs/e2e-testing.md`, `docs/oinc.md`.

## Test plan
- [ ] CI `e2e-tests` on this PR: oinc create succeeds (context `oinc`), MCP CRDs present (`mcpserverregistrations.mcp.kuadrant.io`), developer-portal-controller Available.
- [ ] Host app starts with `yarn dev:oinc`; Playwright against http://localhost:3000 (Dex), not kind.
- [ ] Playwright suite passes (or failures are app/test, not missing MCP/kind env).
- [ ] `unittests` / `build-validate` / `export-plugins` still have no cluster.
- [ ] Local confirm (optional, if an oinc cluster is already up): `yarn dev:oinc` then `cd e2e-tests && yarn test`. Do not recreate/teardown the cluster unless needed.


Made with [Cursor](https://cursor.com)