### PR TITLE
added add read-only detail view for MCPGatewayExtension with test 

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,64 +4,79 @@ The backend plugin exposes REST API endpoints at `/api/kuadrant/*`. All endpoint
 
 ## APIProduct Endpoints
 
-| Method | Endpoint | Description | Permission |
-|--------|----------|-------------|------------|
-| GET | `/api/kuadrant/apiproducts` | List all API Products (filtered by ownership for non-admins) | `kuadrant.apiproduct.list` |
-| GET | `/api/kuadrant/apiproducts/:namespace/:name` | Get specific API Product | `kuadrant.apiproduct.read.own` or `.read.all` |
-| POST | `/api/kuadrant/apiproducts` | Create new API Product | `kuadrant.apiproduct.create` |
-| PATCH | `/api/kuadrant/apiproducts/:namespace/:name` | Update API Product | `kuadrant.apiproduct.update.own` or `.update.all` |
-| DELETE | `/api/kuadrant/apiproducts/:namespace/:name` | Delete API Product (cascades to APIKeys) | `kuadrant.apiproduct.delete.own` or `.delete.all` |
+| Method | Endpoint                                     | Description                                                  | Permission                                        |
+| ------ | -------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------- |
+| GET    | `/api/kuadrant/apiproducts`                  | List all API Products (filtered by ownership for non-admins) | `kuadrant.apiproduct.list`                        |
+| GET    | `/api/kuadrant/apiproducts/:namespace/:name` | Get specific API Product                                     | `kuadrant.apiproduct.read.own` or `.read.all`     |
+| POST   | `/api/kuadrant/apiproducts`                  | Create new API Product                                       | `kuadrant.apiproduct.create`                      |
+| PATCH  | `/api/kuadrant/apiproducts/:namespace/:name` | Update API Product                                           | `kuadrant.apiproduct.update.own` or `.update.all` |
+| DELETE | `/api/kuadrant/apiproducts/:namespace/:name` | Delete API Product (cascades to APIKeys)                     | `kuadrant.apiproduct.delete.own` or `.delete.all` |
 
 ## HTTPRoute Endpoints
 
-| Method | Endpoint | Description | Permission |
-|--------|----------|-------------|------------|
-| GET | `/api/kuadrant/httproutes` | List all HTTPRoutes | `kuadrant.apiproduct.list` |
+| Method | Endpoint                   | Description         | Permission                 |
+| ------ | -------------------------- | ------------------- | -------------------------- |
+| GET    | `/api/kuadrant/httproutes` | List all HTTPRoutes | `kuadrant.apiproduct.list` |
+
+## MCP Management Endpoints
+
+Read-only endpoints backing the MCP Management overview and resource detail views.
+
+| Method | Endpoint                                               | Description                                      | Permission                            |
+| ------ | ------------------------------------------------------ | ------------------------------------------------ | ------------------------------------- |
+| GET    | `/api/kuadrant/gateways`                               | List Gateways (minimal projection)               | `kuadrant.gateway.list`               |
+| GET    | `/api/kuadrant/mcp/gatewayextensions`                  | List MCPGatewayExtensions (minimal projection)   | `kuadrant.mcpgatewayextension.list`   |
+| GET    | `/api/kuadrant/mcp/gatewayextensions/:namespace/:name` | Get a single MCPGatewayExtension (full resource) | `kuadrant.mcpgatewayextension.list`   |
+| GET    | `/api/kuadrant/mcp/serverregistrations`                | List MCPServerRegistrations (minimal projection) | `kuadrant.mcpserverregistration.list` |
+
+The list endpoints return only the fields the overview needs (name, namespace, targetRef, conditions). The detail endpoint returns the full resource manifest — including labels, annotations, owner references and creation timestamp — because the read-only detail view renders both a Details tab and a raw YAML tab. It responds `400` if `namespace` or `name` is missing, `403` when the permission is denied, and `500` on a Kubernetes client error.
 
 ## PlanPolicy Endpoints
 
-| Method | Endpoint | Description | Permission |
-|--------|----------|-------------|------------|
-| GET | `/api/kuadrant/planpolicies` | List all Plan Policies | `kuadrant.planpolicy.list` |
-| GET | `/api/kuadrant/planpolicies/:namespace/:name` | Get specific Plan Policy | `kuadrant.planpolicy.read` |
+| Method | Endpoint                                      | Description              | Permission                 |
+| ------ | --------------------------------------------- | ------------------------ | -------------------------- |
+| GET    | `/api/kuadrant/planpolicies`                  | List all Plan Policies   | `kuadrant.planpolicy.list` |
+| GET    | `/api/kuadrant/planpolicies/:namespace/:name` | Get specific Plan Policy | `kuadrant.planpolicy.read` |
 
 ## AuthPolicy Endpoints
 
-| Method | Endpoint | Description | Permission |
-|--------|----------|-------------|------------|
-| GET | `/api/kuadrant/authpolicies` | List all AuthPolicies | `kuadrant.authpolicy.list` |
+| Method | Endpoint                     | Description           | Permission                 |
+| ------ | ---------------------------- | --------------------- | -------------------------- |
+| GET    | `/api/kuadrant/authpolicies` | List all AuthPolicies | `kuadrant.authpolicy.list` |
 
 ## RateLimitPolicy Endpoints
 
-| Method | Endpoint | Description | Permission |
-|--------|----------|-------------|------------|
-| GET | `/api/kuadrant/ratelimitpolicies` | List all RateLimitPolicies | `kuadrant.ratelimitpolicy.list` |
+| Method | Endpoint                          | Description                | Permission                      |
+| ------ | --------------------------------- | -------------------------- | ------------------------------- |
+| GET    | `/api/kuadrant/ratelimitpolicies` | List all RateLimitPolicies | `kuadrant.ratelimitpolicy.list` |
 
 ## APIKey Endpoints
 
-| Method | Endpoint | Description | Permission |
-|--------|----------|-------------|------------|
-| GET | `/api/kuadrant/requests` | List API Keys (filtered by ownership) | `kuadrant.apikey.read.own` or `.read.all` |
-| GET | `/api/kuadrant/requests/my` | List current user's API Keys | `kuadrant.apikey.read.own` |
-| POST | `/api/kuadrant/requests` | Create API Key request | `kuadrant.apikey.create` |
-| PATCH | `/api/kuadrant/requests/:namespace/:name` | Edit pending request | `kuadrant.apikey.update.own` or `.update.all` |
-| DELETE | `/api/kuadrant/requests/:namespace/:name` | Delete/cancel request | `kuadrant.apikey.delete.own` or `.delete.all` |
-| POST | `/api/kuadrant/requests/:namespace/:name/approve` | Approve request | `kuadrant.apikey.approve` |
-| POST | `/api/kuadrant/requests/:namespace/:name/reject` | Reject request | `kuadrant.apikey.approve` |
-| POST | `/api/kuadrant/requests/bulk-approve` | Bulk approve requests | `kuadrant.apikey.approve` |
-| POST | `/api/kuadrant/requests/bulk-reject` | Bulk reject requests | `kuadrant.apikey.approve` |
+| Method | Endpoint                                          | Description                           | Permission                                    |
+| ------ | ------------------------------------------------- | ------------------------------------- | --------------------------------------------- |
+| GET    | `/api/kuadrant/requests`                          | List API Keys (filtered by ownership) | `kuadrant.apikey.read.own` or `.read.all`     |
+| GET    | `/api/kuadrant/requests/my`                       | List current user's API Keys          | `kuadrant.apikey.read.own`                    |
+| POST   | `/api/kuadrant/requests`                          | Create API Key request                | `kuadrant.apikey.create`                      |
+| PATCH  | `/api/kuadrant/requests/:namespace/:name`         | Edit pending request                  | `kuadrant.apikey.update.own` or `.update.all` |
+| DELETE | `/api/kuadrant/requests/:namespace/:name`         | Delete/cancel request                 | `kuadrant.apikey.delete.own` or `.delete.all` |
+| POST   | `/api/kuadrant/requests/:namespace/:name/approve` | Approve request                       | `kuadrant.apikey.approve`                     |
+| POST   | `/api/kuadrant/requests/:namespace/:name/reject`  | Reject request                        | `kuadrant.apikey.approve`                     |
+| POST   | `/api/kuadrant/requests/bulk-approve`             | Bulk approve requests                 | `kuadrant.apikey.approve`                     |
+| POST   | `/api/kuadrant/requests/bulk-reject`              | Bulk reject requests                  | `kuadrant.apikey.approve`                     |
 
 ## API Key Secret Endpoints
 
-| Method | Endpoint | Description | Permission |
-|--------|----------|-------------|------------|
-| GET | `/api/kuadrant/apikeys/:namespace/:name/secret` | Get API key secret (one-time read) | `kuadrant.apikey.read.own` or `.read.all` |
+| Method | Endpoint                                        | Description                        | Permission                                |
+| ------ | ----------------------------------------------- | ---------------------------------- | ----------------------------------------- |
+| GET    | `/api/kuadrant/apikeys/:namespace/:name/secret` | Get API key secret (one-time read) | `kuadrant.apikey.read.own` or `.read.all` |
 
 ## Query Parameters
 
 **`GET /api/kuadrant/requests`:**
+
 - `status` - Filter by status: `Pending`, `Approved`, `Rejected`
 - `namespace` - Filter by Kubernetes namespace
 
 **`GET /api/kuadrant/requests/my`:**
+
 - `namespace` - Filter by Kubernetes namespace

--- a/e2e-tests/playwright/e2e/kuadrant-mcp-gatewayextension-detail.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-mcp-gatewayextension-detail.spec.ts
@@ -1,22 +1,6 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { Common } from "../utils/common";
-import { TIMEOUTS } from "../utils/kuadrant-helpers";
-
-// the shared waitForKuadrantPageReady helper is hardcoded to the API Products
-// page (URL + heading), so the MCP overview needs its own readiness check.
-async function waitForMcpPageReady(page: Page): Promise<void> {
-  await page.waitForURL(/\/kuadrant\/mcp-management/, {
-    timeout: TIMEOUTS.VERY_SLOW,
-  });
-  await page.waitForLoadState("load").catch(() => {});
-
-  await expect(async () => {
-    const spinner = page.locator('[role="progressbar"]:visible');
-    await expect(spinner).toHaveCount(0);
-    const heading = page.locator("h1").filter({ hasText: /mcp management/i });
-    await expect(heading).toBeVisible();
-  }).toPass({ timeout: TIMEOUTS.VERY_SLOW, intervals: [500, 1000, 2000] });
-}
+import { TIMEOUTS, waitForMcpPageReady } from "../utils/kuadrant-helpers";
 
 test.describe("Kuadrant MCP Gateway Extension detail", () => {
   let common: Common;

--- a/e2e-tests/playwright/e2e/kuadrant-mcp-gatewayextension-detail.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-mcp-gatewayextension-detail.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, Page } from "@playwright/test";
+import { Common } from "../utils/common";
+import { TIMEOUTS } from "../utils/kuadrant-helpers";
+
+// the shared waitForKuadrantPageReady helper is hardcoded to the API Products
+// page (URL + heading), so the MCP overview needs its own readiness check.
+async function waitForMcpPageReady(page: Page): Promise<void> {
+  await page.waitForURL(/\/kuadrant\/mcp-management/, {
+    timeout: TIMEOUTS.VERY_SLOW,
+  });
+  await page.waitForLoadState("load").catch(() => {});
+
+  await expect(async () => {
+    const spinner = page.locator('[role="progressbar"]:visible');
+    await expect(spinner).toHaveCount(0);
+    const heading = page.locator("h1").filter({ hasText: /mcp management/i });
+    await expect(heading).toBeVisible();
+  }).toPass({ timeout: TIMEOUTS.VERY_SLOW, intervals: [500, 1000, 2000] });
+}
+
+test.describe("Kuadrant MCP Gateway Extension detail", () => {
+  let common: Common;
+
+  test.beforeAll(async () => {
+    test.info().annotations.push({
+      type: "component",
+      description: "plugins",
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    common = new Common(page);
+    await common.loginAsGuest();
+    await page.goto("/kuadrant/mcp-management");
+    await waitForMcpPageReady(page);
+  });
+
+  test("opens the detail page from the extensions table", async ({ page }) => {
+    // the extension name is a link into the read-only detail view; skip when the
+    // cluster has no MCPGatewayExtensions to open (nothing to assert on)
+
+    // wait for the extension link to appear (async data load from backend)
+    const extensionLink = page
+      .locator('a[href^="/kuadrant/mcp/gatewayextensions/"]')
+      .first();
+
+    try {
+      await extensionLink.waitFor({
+        state: "attached",
+        timeout: TIMEOUTS.SLOW,
+      });
+    } catch {
+      test.skip(true, "no MCPGatewayExtensions present in the cluster");
+      return;
+    }
+
+    await extensionLink.click();
+
+    await page.waitForURL(/\/kuadrant\/mcp\/gatewayextensions\/[^/]+\/[^/]+/, {
+      timeout: TIMEOUTS.VERY_SLOW,
+    });
+
+    // Details and YAML tabs are the two read-only views described in the ticket
+    await expect(page.getByRole("tab", { name: /details/i })).toBeVisible({
+      timeout: TIMEOUTS.SLOW,
+    });
+    await expect(page.getByRole("tab", { name: /yaml/i })).toBeVisible();
+
+    // details tab shows the resource fields
+    await expect(page.getByText("Resource Details").first()).toBeVisible({
+      timeout: TIMEOUTS.SLOW,
+    });
+
+    // breadcrumb links back to the overview
+    const breadcrumb = page.locator('a[href="/kuadrant/mcp-management"]', {
+      hasText: /mcp overview/i,
+    });
+    await expect(breadcrumb.first()).toBeVisible();
+  });
+
+  test("shows the read-only YAML manifest", async ({ page }) => {
+    const extensionLink = page
+      .locator('a[href^="/kuadrant/mcp/gatewayextensions/"]')
+      .first();
+
+    try {
+      await extensionLink.waitFor({
+        state: "attached",
+        timeout: TIMEOUTS.SLOW,
+      });
+    } catch {
+      test.skip(true, "no MCPGatewayExtensions present in the cluster");
+      return;
+    }
+
+    await extensionLink.click();
+    await page.waitForURL(/\/kuadrant\/mcp\/gatewayextensions\/[^/]+\/[^/]+/, {
+      timeout: TIMEOUTS.VERY_SLOW,
+    });
+
+    await page.getByRole("tab", { name: /yaml/i }).click();
+
+    await expect(page.getByText("YAML Manifest").first()).toBeVisible({
+      timeout: TIMEOUTS.SLOW,
+    });
+    // the manifest renders apiVersion of the MCPGatewayExtension resource
+    await expect(
+      page.getByText(/apiVersion:\s*mcp\.kuadrant\.io/).first(),
+    ).toBeVisible();
+  });
+});

--- a/e2e-tests/playwright/e2e/kuadrant-mcp.spec.ts
+++ b/e2e-tests/playwright/e2e/kuadrant-mcp.spec.ts
@@ -1,22 +1,6 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { Common } from "../utils/common";
-import { TIMEOUTS } from "../utils/kuadrant-helpers";
-
-// the shared waitForKuadrantPageReady helper is hardcoded to the API Products
-// page (URL + heading), so the MCP page needs its own readiness check.
-async function waitForMcpPageReady(page: Page): Promise<void> {
-  await page.waitForURL(/\/kuadrant\/mcp-management/, {
-    timeout: TIMEOUTS.VERY_SLOW,
-  });
-  await page.waitForLoadState("load").catch(() => {});
-
-  await expect(async () => {
-    const spinner = page.locator('[role="progressbar"]:visible');
-    await expect(spinner).toHaveCount(0);
-    const heading = page.locator("h1").filter({ hasText: /mcp management/i });
-    await expect(heading).toBeVisible();
-  }).toPass({ timeout: TIMEOUTS.VERY_SLOW, intervals: [500, 1000, 2000] });
-}
+import { TIMEOUTS, waitForMcpPageReady } from "../utils/kuadrant-helpers";
 
 test.describe("Kuadrant MCP Management", () => {
   let common: Common;

--- a/e2e-tests/playwright/utils/kuadrant-helpers.ts
+++ b/e2e-tests/playwright/utils/kuadrant-helpers.ts
@@ -162,6 +162,26 @@ export async function waitForApiKeysPageReady(
   }).toPass({ timeout: TIMEOUTS.VERY_SLOW, intervals: [500, 1000, 2000] });
 }
 
+/**
+ * Wait for MCP management pages to be ready (shared across MCP specs).
+ * Default pattern matches /kuadrant/mcp-management (overview) and detail pages.
+ */
+export async function waitForMcpPageReady(
+  page: Page,
+  urlPattern: RegExp = /\/kuadrant\/mcp/,
+  headingPattern: RegExp = /mcp/i,
+): Promise<void> {
+  await page.waitForURL(urlPattern, { timeout: TIMEOUTS.VERY_SLOW });
+  await page.waitForLoadState("load").catch(() => {});
+
+  await expect(async () => {
+    const spinner = page.locator('[role="progressbar"]:visible');
+    await expect(spinner).toHaveCount(0);
+    const heading = page.locator("h1").filter({ hasText: headingPattern });
+    await expect(heading).toBeVisible();
+  }).toPass({ timeout: TIMEOUTS.VERY_SLOW, intervals: [500, 1000, 2000] });
+}
+
 /** Open a MUI Select via its listbox button (testid click misses the menu in CI). */
 export async function openMuiSelect(
   page: Page,

--- a/packages/app/src/components/AppBase/AppBase.tsx
+++ b/packages/app/src/components/AppBase/AppBase.tsx
@@ -26,6 +26,7 @@ import {
   ApiKeyDetailPage,
   ApiProductDetailPage,
   ApiProductsPage,
+  McpGatewayExtensionDetailPage,
   McpOverviewPage,
   MyApiKeysPage,
 } from '@kuadrant/kuadrant-backstage-plugin-frontend';
@@ -154,6 +155,10 @@ const AppBase = () => {
               <Route
                 path="/kuadrant/mcp-management"
                 element={<McpOverviewPage />}
+              />
+              <Route
+                path="/kuadrant/mcp/gatewayextensions/:namespace/:name"
+                element={<McpGatewayExtensionDetailPage />}
               />
               <Route path="/kuadrant/my-api-keys" element={<MyApiKeysPage />} />
               <Route

--- a/plugins/kuadrant-backend/src/router.test.ts
+++ b/plugins/kuadrant-backend/src/router.test.ts
@@ -1642,6 +1642,78 @@ describe('createRouter', () => {
     });
   });
 
+  describe('GET /mcp/gatewayextensions/:namespace/:name', () => {
+    const namespace = 'mcp-system';
+    const name = 'ext-1';
+
+    const mockExtension = {
+      apiVersion: 'mcp.kuadrant.io/v1',
+      kind: 'MCPGatewayExtension',
+      metadata: {
+        name,
+        namespace,
+        uid: 'abc-123',
+        creationTimestamp: '2026-08-01T10:00:00Z',
+        labels: { app: 'mcp' },
+        annotations: { 'kuadrant.io/note': 'demo' },
+        ownerReferences: [{ kind: 'Gateway', name: 'gw-1' }],
+      },
+      spec: {
+        targetRef: {
+          group: 'gateway.networking.k8s.io',
+          kind: 'Gateway',
+          name: 'gw-1',
+          namespace: 'gateway-system',
+        },
+      },
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    };
+
+    beforeEach(() => {
+      mockAuthorizeFn.mockReset();
+    });
+
+    it('returns the full mcpgatewayextension when permission is allowed', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.getCustomResource.mockResolvedValueOnce(mockExtension);
+
+      const response = await request(app)
+        .get(`/mcp/gatewayextensions/${namespace}/${name}`)
+        .expect(200);
+
+      // detail endpoint returns the full resource unprojected (labels,
+      // annotations, ownerReferences etc. are all needed by the detail view)
+      expect(response.body).toEqual(mockExtension);
+      expect(mockK8sClient.getCustomResource).toHaveBeenCalledWith(
+        'mcp.kuadrant.io',
+        'v1',
+        namespace,
+        'mcpgatewayextensions',
+        name,
+      );
+    });
+
+    it('returns 403 when the extension list permission is denied', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.DENY }]);
+
+      const response = await request(app)
+        .get(`/mcp/gatewayextensions/${namespace}/${name}`)
+        .expect(403);
+      expect(response.body.error).toBe('unauthorised');
+      expect(mockK8sClient.getCustomResource).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 when the k8s client fails', async () => {
+      mockAuthorizeFn.mockResolvedValueOnce([{ result: AuthorizeResult.ALLOW }]);
+      mockK8sClient.getCustomResource.mockRejectedValueOnce(new Error('boom'));
+
+      const response = await request(app)
+        .get(`/mcp/gatewayextensions/${namespace}/${name}`)
+        .expect(500);
+      expect(response.body.error).toBe('failed to fetch mcpgatewayextension');
+    });
+  });
+
   describe('GET /mcp/serverregistrations', () => {
     beforeEach(() => {
       mockAuthorizeFn.mockReset();

--- a/plugins/kuadrant-backend/src/router.ts
+++ b/plugins/kuadrant-backend/src/router.ts
@@ -1889,6 +1889,45 @@ export async function createRouter({
     }
   });
 
+  router.get('/mcp/gatewayextensions/:namespace/:name', async (req, res) => {
+    try {
+      const credentials = await httpAuth.credentials(req);
+
+      const decision = await permissions.authorize(
+        [{ permission: kuadrantMcpGatewayExtensionListPermission }],
+        { credentials }
+      );
+
+      if (decision[0].result !== AuthorizeResult.ALLOW) {
+        throw new NotAllowedError('unauthorised');
+      }
+
+      const { namespace, name } = req.params;
+
+      if (!namespace || !name) {
+        res.status(400).json({ error: 'namespace and name are required' });
+        return;
+      }
+
+      const data = await k8sClient.getCustomResource(
+        'mcp.kuadrant.io',
+        'v1',
+        namespace,
+        'mcpgatewayextensions',
+        name
+      );
+
+      res.json(data);
+    } catch (error) {
+      console.error('error fetching mcpgatewayextension:', error);
+      if (error instanceof NotAllowedError) {
+        res.status(403).json({ error: error.message });
+      } else {
+        res.status(500).json({ error: 'failed to fetch mcpgatewayextension' });
+      }
+    }
+  });
+
   router.get('/mcp/serverregistrations', async (req, res) => {
     try {
       const credentials = await httpAuth.credentials(req);

--- a/plugins/kuadrant/package.json
+++ b/plugins/kuadrant/package.json
@@ -70,6 +70,7 @@
     "@mui/icons-material": "5.18.0",
     "@mui/material": "5.18.0",
     "async-retry": "^1.3.3",
+    "js-yaml": "^4.1.0",
     "react-router-dom": "^6.0.0",
     "react-use": "^17.2.4"
   },
@@ -87,6 +88,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.0.0",
     "@types/async-retry": "^1.4.9",
+    "@types/js-yaml": "^4.0.9",
     "msw": "^1.0.0",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",

--- a/plugins/kuadrant/src/api.ts
+++ b/plugins/kuadrant/src/api.ts
@@ -282,6 +282,14 @@ export interface KuadrantAPI {
   getMcpGatewayExtensions(): Promise<KuadrantList<MCPGatewayExtension>>;
 
   /**
+   * Fetch a single MCPGatewayExtension
+   * @param namespace - Kubernetes namespace
+   * @param name - MCPGatewayExtension name
+   * @returns Promise with the MCP gateway extension
+   */
+  getMcpGatewayExtension(namespace: string, name: string): Promise<MCPGatewayExtension>;
+
+  /**
    * Fetch all MCPServerRegistrations
    * @returns Promise with list of MCP server registrations
    */
@@ -626,6 +634,14 @@ export class KuadrantApiClient implements KuadrantAPI {
     return this.fetchWithRetry(
       `${baseUrl}kuadrant/mcp/gatewayextensions`,
       "Failed to fetch MCPGatewayExtensions."
+    );
+  }
+
+  async getMcpGatewayExtension(namespace: string, name: string): Promise<MCPGatewayExtension> {
+    const baseUrl = await this.getBaseUrl();
+    return this.fetchWithRetry(
+      `${baseUrl}kuadrant/mcp/gatewayextensions/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
+      "Failed to fetch MCPGatewayExtension."
     );
   }
 

--- a/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/McpGatewayExtensionDetailPage.tsx
+++ b/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/McpGatewayExtensionDetailPage.tsx
@@ -229,12 +229,15 @@ export const McpGatewayExtensionDetailPage = () => {
                   </Typography>
                 </Box>
 
-                <Box className={classes.infoItem}>
-                  <Typography variant="caption" className={classes.label}>
-                    Owner
-                  </Typography>
-                  <Typography variant="body2">{owner}</Typography>
-                </Box>
+                {extension.metadata?.ownerReferences &&
+                  extension.metadata.ownerReferences.length > 0 && (
+                    <Box className={classes.infoItem}>
+                      <Typography variant="caption" className={classes.label}>
+                        Owner
+                      </Typography>
+                      <Typography variant="body2">{owner}</Typography>
+                    </Box>
+                  )}
 
                 {extension.spec?.targetRef && (
                   <>

--- a/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/McpGatewayExtensionDetailPage.tsx
+++ b/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/McpGatewayExtensionDetailPage.tsx
@@ -31,6 +31,9 @@ import { ResourceYamlCard } from "../ResourceYamlCard";
 import { formatAge, formatOwner, isExtensionReady } from "./utils";
 
 const useStyles = makeStyles((theme) => ({
+  tabs: {
+    marginLeft: theme.spacing(-3),
+  },
   label: {
     fontWeight: 600,
     color: theme.palette.text.secondary,
@@ -171,6 +174,7 @@ export const McpGatewayExtensionDetailPage = () => {
             onChange={(_, newValue) => setSelectedTab(newValue)}
             indicatorColor="primary"
             textColor="primary"
+            className={classes.tabs}
           >
             <Tab label="Details" />
             <Tab label="YAML" />

--- a/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/McpGatewayExtensionDetailPage.tsx
+++ b/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/McpGatewayExtensionDetailPage.tsx
@@ -1,0 +1,333 @@
+import React, { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useApi } from "@backstage/core-plugin-api";
+import { kuadrantApiRef } from "../../api";
+import { useAsync } from "react-use";
+import {
+  Header,
+  Page,
+  Content,
+  ResponseErrorPanel,
+  InfoCard,
+  Link,
+  Breadcrumbs,
+  Table,
+  TableColumn,
+} from "@backstage/core-components";
+import {
+  Box,
+  Typography,
+  Button,
+  Tabs,
+  Tab,
+  Chip,
+  makeStyles,
+  Grid,
+} from "@material-ui/core";
+import { Skeleton } from "@material-ui/lab";
+import ArrowBackIcon from "@material-ui/icons/ArrowBack";
+import { MCPGatewayExtension, McpCondition } from "../../types/mcp";
+import { ResourceYamlCard } from "../ResourceYamlCard";
+import { formatAge, formatOwner, isExtensionReady } from "./utils";
+
+const useStyles = makeStyles((theme) => ({
+  label: {
+    fontWeight: 600,
+    color: theme.palette.text.secondary,
+    marginBottom: theme.spacing(0.5),
+    fontSize: "0.75rem",
+    textTransform: "uppercase",
+  },
+  infoGrid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+    gap: theme.spacing(3),
+    marginBottom: theme.spacing(3),
+  },
+  infoItem: {
+    minWidth: 0,
+  },
+  statusChipReady: {
+    backgroundColor: theme.palette.success.main,
+    color: theme.palette.common.white,
+  },
+  statusChipNotReady: {
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.common.white,
+  },
+}));
+
+export const McpGatewayExtensionDetailPage = () => {
+  const classes = useStyles();
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+  const kuadrantApi = useApi(kuadrantApiRef);
+
+  const [selectedTab, setSelectedTab] = useState(0);
+
+  const {
+    value: extension,
+    loading,
+    error,
+  } = useAsync(async () => {
+    return (await kuadrantApi.getMcpGatewayExtension(
+      namespace!,
+      name!,
+    )) as MCPGatewayExtension;
+  }, [namespace, name, kuadrantApi]);
+
+  if (loading) {
+    return (
+      <Page themeId="tool">
+        <Header title="Loading..." />
+        <Content>
+          <Box p={2}>
+            {[...Array(5)].map((_, i) => (
+              <Box key={i} p={2}>
+                <Skeleton variant="text" width="100%" />
+              </Box>
+            ))}
+          </Box>
+        </Content>
+      </Page>
+    );
+  }
+
+  if (error || !extension) {
+    return (
+      <ResponseErrorPanel
+        error={error || new Error("MCP Gateway Extension not found")}
+      />
+    );
+  }
+
+  const conditions = extension.status?.conditions || [];
+  const ready = isExtensionReady(extension);
+  const labels = extension.metadata?.labels || {};
+  const annotations = extension.metadata?.annotations || {};
+  const createdAt = extension.metadata?.creationTimestamp;
+  const owner = formatOwner(extension);
+
+  const conditionsColumns: TableColumn<McpCondition>[] = [
+    {
+      title: "Type",
+      field: "type",
+      render: (row) => <strong>{row.type}</strong>,
+    },
+    {
+      title: "Status",
+      field: "status",
+      render: (row) => (
+        <Chip
+          label={row.status}
+          size="small"
+          style={{
+            backgroundColor:
+              row.status === "True" ? "var(--rh-green, #3e8635)" : undefined,
+            color: row.status === "True" ? "white" : undefined,
+          }}
+        />
+      ),
+    },
+    {
+      title: "Updated",
+      field: "lastTransitionTime",
+      render: (row) => formatAge(row.lastTransitionTime),
+    },
+    {
+      title: "Reason",
+      field: "reason",
+      render: (row) => row.reason || "-",
+    },
+    {
+      title: "Message",
+      field: "message",
+      render: (row) => row.message || "-",
+    },
+  ];
+
+  return (
+    <Page themeId="tool">
+      <Header
+        title={extension.metadata?.name || "MCP Gateway Extension"}
+        subtitle={`Namespace: ${extension.metadata?.namespace || "-"}`}
+      >
+        <Link to="/kuadrant/mcp-management">
+          <Button startIcon={<ArrowBackIcon />}>Back to MCP Overview</Button>
+        </Link>
+      </Header>
+      <Content>
+        <Box mb={2}>
+          <Breadcrumbs aria-label="breadcrumb">
+            <Link to="/kuadrant/mcp-management">MCP Overview</Link>
+            <Typography>
+              {extension.metadata?.name || "Gateway Extension"}
+            </Typography>
+          </Breadcrumbs>
+        </Box>
+
+        <Box mb={2}>
+          <Tabs
+            value={selectedTab}
+            onChange={(_, newValue) => setSelectedTab(newValue)}
+            indicatorColor="primary"
+            textColor="primary"
+          >
+            <Tab label="Details" />
+            <Tab label="YAML" />
+          </Tabs>
+        </Box>
+
+        {selectedTab === 0 && (
+          <>
+            <InfoCard title="Resource Details">
+              <Box className={classes.infoGrid}>
+                <Box className={classes.infoItem}>
+                  <Typography variant="caption" className={classes.label}>
+                    Name
+                  </Typography>
+                  <Typography variant="body2">
+                    {extension.metadata?.name || "-"}
+                  </Typography>
+                </Box>
+
+                <Box className={classes.infoItem}>
+                  <Typography variant="caption" className={classes.label}>
+                    Namespace
+                  </Typography>
+                  <Typography variant="body2">
+                    {extension.metadata?.namespace || "-"}
+                  </Typography>
+                </Box>
+
+                <Box className={classes.infoItem}>
+                  <Typography variant="caption" className={classes.label}>
+                    Status
+                  </Typography>
+                  <Box>
+                    <Chip
+                      label={ready ? "Ready" : "Not Ready"}
+                      size="small"
+                      className={
+                        ready
+                          ? classes.statusChipReady
+                          : classes.statusChipNotReady
+                      }
+                    />
+                  </Box>
+                </Box>
+
+                <Box className={classes.infoItem}>
+                  <Typography variant="caption" className={classes.label}>
+                    Created At
+                  </Typography>
+                  <Typography variant="body2">
+                    {createdAt ? new Date(createdAt).toLocaleString() : "-"}
+                  </Typography>
+                </Box>
+
+                <Box className={classes.infoItem}>
+                  <Typography variant="caption" className={classes.label}>
+                    Owner
+                  </Typography>
+                  <Typography variant="body2">{owner}</Typography>
+                </Box>
+
+                {extension.spec?.targetRef && (
+                  <>
+                    <Box className={classes.infoItem}>
+                      <Typography variant="caption" className={classes.label}>
+                        Target Gateway
+                      </Typography>
+                      <Typography variant="body2">
+                        {extension.spec.targetRef.name || "-"}
+                      </Typography>
+                    </Box>
+
+                    <Box className={classes.infoItem}>
+                      <Typography variant="caption" className={classes.label}>
+                        Target Group
+                      </Typography>
+                      <Typography variant="body2">
+                        {extension.spec.targetRef.group ||
+                          "gateway.networking.k8s.io"}
+                      </Typography>
+                    </Box>
+
+                    <Box className={classes.infoItem}>
+                      <Typography variant="caption" className={classes.label}>
+                        Target Kind
+                      </Typography>
+                      <Typography variant="body2">
+                        {extension.spec.targetRef.kind || "Gateway"}
+                      </Typography>
+                    </Box>
+                  </>
+                )}
+              </Box>
+
+              {Object.keys(labels).length > 0 && (
+                <Box mb={3}>
+                  <Typography variant="caption" className={classes.label}>
+                    Labels
+                  </Typography>
+                  <Grid container spacing={1}>
+                    {Object.entries(labels).map(([key, value]) => (
+                      <Grid item key={key}>
+                        <Chip
+                          label={`${key}: ${value}`}
+                          size="small"
+                          variant="outlined"
+                        />
+                      </Grid>
+                    ))}
+                  </Grid>
+                </Box>
+              )}
+
+              {Object.keys(annotations).length > 0 && (
+                <Box mb={3}>
+                  <Typography variant="caption" className={classes.label}>
+                    Annotations
+                  </Typography>
+                  <Grid container spacing={1}>
+                    {Object.entries(annotations).map(([key, value]) => (
+                      <Grid item key={key} xs={12}>
+                        <Typography
+                          variant="body2"
+                          style={{
+                            fontFamily: "monospace",
+                            fontSize: "0.75rem",
+                          }}
+                        >
+                          <strong>{key}:</strong> {String(value)}
+                        </Typography>
+                      </Grid>
+                    ))}
+                  </Grid>
+                </Box>
+              )}
+            </InfoCard>
+
+            {conditions.length > 0 && (
+              <Box mt={3}>
+                <InfoCard title="Conditions">
+                  <Table<McpCondition>
+                    options={{
+                      paging: false,
+                      search: false,
+                      toolbar: false,
+                    }}
+                    columns={conditionsColumns}
+                    data={conditions}
+                  />
+                </InfoCard>
+              </Box>
+            )}
+          </>
+        )}
+
+        {selectedTab === 1 && <ResourceYamlCard resource={extension} />}
+      </Content>
+    </Page>
+  );
+};

--- a/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/index.ts
+++ b/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/index.ts
@@ -1,0 +1,1 @@
+export { McpGatewayExtensionDetailPage } from "./McpGatewayExtensionDetailPage";

--- a/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/utils.test.ts
+++ b/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/utils.test.ts
@@ -1,0 +1,107 @@
+import { MCPGatewayExtension, McpCondition } from "../../types/mcp";
+import { formatAge, formatOwner, isExtensionReady } from "./utils";
+
+const cond = (
+  type: string,
+  status: "True" | "False" | "Unknown",
+): McpCondition => ({ type, status });
+
+const extension = (
+  opts: {
+    conditions?: McpCondition[];
+    ownerReferences?: MCPGatewayExtension["metadata"]["ownerReferences"];
+  } = {},
+): MCPGatewayExtension => ({
+  metadata: {
+    name: "ext",
+    namespace: "ns",
+    ...(opts.ownerReferences ? { ownerReferences: opts.ownerReferences } : {}),
+  },
+  spec: { targetRef: { name: "gw" } },
+  status: opts.conditions ? { conditions: opts.conditions } : undefined,
+});
+
+describe("isExtensionReady", () => {
+  it("is ready when the Ready condition is True", () => {
+    expect(
+      isExtensionReady(extension({ conditions: [cond("Ready", "True")] })),
+    ).toBe(true);
+  });
+
+  it("is not ready when the Ready condition is False", () => {
+    expect(
+      isExtensionReady(extension({ conditions: [cond("Ready", "False")] })),
+    ).toBe(false);
+  });
+
+  it("is not ready when status is missing", () => {
+    expect(isExtensionReady(extension())).toBe(false);
+  });
+
+  it("is not ready when only a different condition is True", () => {
+    expect(
+      isExtensionReady(extension({ conditions: [cond("Accepted", "True")] })),
+    ).toBe(false);
+  });
+});
+
+describe("formatAge", () => {
+  const now = new Date("2026-08-20T12:00:00Z").getTime();
+
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(now);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns '-' when no timestamp is given", () => {
+    expect(formatAge(undefined)).toBe("-");
+  });
+
+  it("formats a multi-day age in days", () => {
+    expect(formatAge("2026-08-17T12:00:00Z")).toBe("3d");
+  });
+
+  it("formats a multi-hour age in hours", () => {
+    expect(formatAge("2026-08-20T10:00:00Z")).toBe("2h");
+  });
+
+  it("formats a multi-minute age in minutes", () => {
+    expect(formatAge("2026-08-20T11:55:00Z")).toBe("5m");
+  });
+
+  it("returns 'just now' for a sub-minute age", () => {
+    expect(formatAge("2026-08-20T11:59:30Z")).toBe("just now");
+  });
+});
+
+describe("formatOwner", () => {
+  it("builds a Kind/name label from the first owner reference", () => {
+    expect(
+      formatOwner(
+        extension({
+          ownerReferences: [{ kind: "Gateway", name: "prod-gateway" }],
+        }),
+      ),
+    ).toBe("Gateway/prod-gateway");
+  });
+
+  it("uses the first owner reference when several are present", () => {
+    expect(
+      formatOwner(
+        extension({
+          ownerReferences: [
+            { kind: "Gateway", name: "first" },
+            { kind: "Service", name: "second" },
+          ],
+        }),
+      ),
+    ).toBe("Gateway/first");
+  });
+
+  it("falls back to a placeholder when there is no owner reference", () => {
+    expect(formatOwner(extension())).toBe("No owner reference");
+  });
+});

--- a/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/utils.ts
+++ b/plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/utils.ts
@@ -1,0 +1,30 @@
+import { MCPGatewayExtension } from "../../types/mcp";
+import { hasCondition } from "../McpOverviewPage/utils";
+
+/** an extension is ready when it has a 'True' status for the 'Ready' condition */
+export function isExtensionReady(ext: MCPGatewayExtension): boolean {
+  return hasCondition(ext.status?.conditions, "Ready");
+}
+
+/**
+ * formats a k8s timestamp as a compact relative age (e.g. "3d", "2h", "5m").
+ * returns "-" when no timestamp is present.
+ */
+export function formatAge(timestamp?: string): string {
+  if (!timestamp) return "-";
+  const diffMs = Date.now() - new Date(timestamp).getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays > 0) return `${diffDays}d`;
+  if (diffHours > 0) return `${diffHours}h`;
+  if (diffMins > 0) return `${diffMins}m`;
+  return "just now";
+}
+
+/** builds the `Kind/name` label for an extension's first owner reference */
+export function formatOwner(ext: MCPGatewayExtension): string {
+  const ownerRef = ext.metadata?.ownerReferences?.[0];
+  return ownerRef ? `${ownerRef.kind}/${ownerRef.name}` : "No owner reference";
+}

--- a/plugins/kuadrant/src/components/McpOverviewPage/McpOverviewPage.tsx
+++ b/plugins/kuadrant/src/components/McpOverviewPage/McpOverviewPage.tsx
@@ -27,6 +27,7 @@ import {
   Header,
   Content,
   InfoCard,
+  Link,
   SupportButton,
   ResponseErrorPanel,
   Table,
@@ -652,7 +653,13 @@ const McpContent = () => {
     {
       title: "Extension name",
       field: "metadata.name",
-      render: (row) => <strong>{row.metadata?.name}</strong>,
+      render: (row) => (
+        <Link
+          to={`/kuadrant/mcp/gatewayextensions/${row.metadata?.namespace}/${row.metadata?.name}`}
+        >
+          <strong>{row.metadata?.name}</strong>
+        </Link>
+      ),
     },
     {
       title: "Gateway name",

--- a/plugins/kuadrant/src/components/ResourceYamlCard/ResourceYamlCard.tsx
+++ b/plugins/kuadrant/src/components/ResourceYamlCard/ResourceYamlCard.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { InfoCard, CodeSnippet } from "@backstage/core-components";
+import yaml from "js-yaml";
+
+/**
+ * read-only YAML view of any k8s-style resource: dumps the object to YAML and
+ * renders it in a syntax-highlighted, copyable, non-editable code block.
+ * shared across read-only resource detail pages.
+ */
+export const ResourceYamlCard = ({
+  resource,
+  title = "YAML Manifest",
+}: {
+  resource: unknown;
+  title?: string;
+}) => (
+  <InfoCard title={title}>
+    <CodeSnippet
+      text={yaml.dump(resource)}
+      language="yaml"
+      showLineNumbers
+      showCopyCodeButton
+    />
+  </InfoCard>
+);

--- a/plugins/kuadrant/src/components/ResourceYamlCard/index.ts
+++ b/plugins/kuadrant/src/components/ResourceYamlCard/index.ts
@@ -1,0 +1,1 @@
+export { ResourceYamlCard } from "./ResourceYamlCard";

--- a/plugins/kuadrant/src/index.ts
+++ b/plugins/kuadrant/src/index.ts
@@ -7,6 +7,7 @@ export {
   ApiKeyDetailPage,
   ApiProductDetailPage,
   McpOverviewPage,
+  McpGatewayExtensionDetailPage,
   EntityKuadrantApiAccessCard,
   EntityKuadrantApiKeyManagementTab,
   EntityKuadrantApiKeysContent,

--- a/plugins/kuadrant/src/plugin.ts
+++ b/plugins/kuadrant/src/plugin.ts
@@ -127,3 +127,12 @@ export const McpOverviewPage = kuadrantPlugin.provide(
     mountPoint: rootRouteRef,
   }),
 );
+
+export const McpGatewayExtensionDetailPage = kuadrantPlugin.provide(
+  createRoutableExtension({
+    name: 'McpGatewayExtensionDetailPage',
+    component: () =>
+      import('./components/McpGatewayExtensionDetailPage').then(m => m.McpGatewayExtensionDetailPage),
+    mountPoint: rootRouteRef,
+  }),
+);

--- a/plugins/kuadrant/src/types/mcp.ts
+++ b/plugins/kuadrant/src/types/mcp.ts
@@ -17,6 +17,15 @@ export interface McpCondition {
 export interface McpObjectMeta {
   name: string;
   namespace?: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  creationTimestamp?: string;
+  ownerReferences?: Array<{
+    kind: string;
+    name: string;
+    uid?: string;
+    apiVersion?: string;
+  }>;
 }
 
 export interface McpTargetRef {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11073,7 +11073,9 @@ __metadata:
     "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:^14.0.0"
     "@types/async-retry": "npm:^1.4.9"
+    "@types/js-yaml": "npm:^4.0.9"
     async-retry: "npm:^1.3.3"
+    js-yaml: "npm:^4.1.0"
     msw: "npm:^1.0.0"
     react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     react-dom: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
@@ -20690,7 +20692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-yaml@npm:^4.0.1":
+"@types/js-yaml@npm:^4.0.1, @types/js-yaml@npm:^4.0.9":
   version: 4.0.9
   resolution: "@types/js-yaml@npm:4.0.9"
   checksum: 10c0/24de857aa8d61526bbfbbaa383aa538283ad17363fcd5bb5148e2c7f604547db36646440e739d78241ed008702a8920665d1add5618687b6743858fae00da211


### PR DESCRIPTION
  ## Summary

  Closes #373.

  Adds a read-only detail page for `MCPGatewayExtension` resources, accessible by clicking the extension name in the MCP Overview table.

  **Frontend:**
  - `McpGatewayExtensionDetailPage/` — read-only detail view with two tabs:
    - **Details tab**: Name, Namespace, Status (Ready/Not Ready chip), Created At, Owner, Target Gateway fields, Labels/Annotations chips, Conditions table (Type, Status, Updated, Reason, Message)
    - **YAML tab**: full resource manifest (syntax-highlighted, copyable, read-only)
  - `ResourceYamlCard/` — reusable component for YAML tabs across future read-only resource detail pages (uses `InfoCard` + `CodeSnippet` + `yaml.dump`)
  - Co-located `utils.ts` with helpers: `isExtensionReady`, `formatAge`, `formatOwner`
  - Link in MCP Overview "Extension name" column → `/kuadrant/mcp/gatewayextensions/:namespace/:name`

  **Backend:**
  - `GET /mcp/gatewayextensions/:namespace/:name` — returns full resource (not projected, includes labels/annotations/ownerReferences/creationTimestamp)
  - Authorization: reuses `kuadrant.mcpgatewayextension.list` permission
  - Responds: 400 if namespace/name missing, 403 on permission deny, 500 on k8s error

  **Tests:**
  - Frontend unit: `McpGatewayExtensionDetailPage/utils.test.ts` — 12 tests (isExtensionReady, formatAge, formatOwner)
  - Backend unit: `router.test.ts` — 3 new tests for detail endpoint (200/403/500 cases)
  - E2E: `kuadrant-mcp-gatewayextension-detail.spec.ts` — 2 tests (navigate from table, verify tabs/breadcrumb/YAML manifest). Includes `waitFor` fix for async data load race condition.

  **Docs:**
  - `docs/api-reference.md` — new "MCP Management Endpoints" section documenting detail endpoint + related list endpoints

  ## How to review

  1. **Component structure**: `plugins/kuadrant/src/components/McpGatewayExtensionDetailPage/` — page, utils, utils.test, index. Compare with `ApiProductDetailPage/` pattern (co-located utils, not global helpers).
  2. **ResourceYamlCard reusability**: `plugins/kuadrant/src/components/ResourceYamlCard/` — accepts any `resource: unknown` and `title?: string`. Used in YAML tab; can be reused for
  Gateway/ServerRegistration/HTTPRoute detail pages.
  3. **Backend endpoint**: `plugins/kuadrant-backend/src/router.ts` lines 1892-1929 (`GET /mcp/gatewayextensions/:namespace/:name`). Returns unprojected resource (detail view needs
  labels/annotations/ownerReferences).
  4. **Link wiring**: `plugins/kuadrant/src/components/McpOverviewPage/McpOverviewPage.tsx` line 657-660 — extension name column now renders `<Link to={...}><strong>{name}</strong></Link>`.
  5. **Tests pass**:
     - Frontend unit: `yarn workspace @kuadrant/kuadrant-backstage-plugin-frontend test src/components/McpGatewayExtensionDetailPage/utils.test.ts` (12 passed)
     - Backend unit: `yarn workspace @kuadrant/kuadrant-backstage-plugin-backend test src/router.test.ts -t "gatewayextensions/:namespace"` (3 passed)
     - E2E: `cd e2e-tests && yarn playwright test playwright/e2e/kuadrant-mcp-gatewayextension-detail.spec.ts --project=kuadrant` (2 passed)
  6. **Docs**: `docs/api-reference.md` lines 21-32 — new MCP section, detail endpoint documented

  ## Test plan

  - [x] Frontend utils tests: 12 passed (`isExtensionReady`, `formatAge`, `formatOwner`)
  - [x] Backend router tests: 3 passed (detail endpoint 200/403/500)
  - [x] E2E tests: 2 passed (navigate from table, YAML manifest visible)
  - [x] TypeScript compilation: `yarn tsc` clean (8/8 tasks successful)
  - [x] Formatting: `prettier` clean on all new files
  - [x] Manual verification (oinc cluster):
    - Navigate from http://localhost:3000/kuadrant/mcp-management to extension detail
    - Details tab shows all fields (Status chip, Created At, Owner, targetRef, Labels, Annotations, Conditions table)
    - YAML tab shows full manifest with `apiVersion: mcp.kuadrant.io/v1`
    - Breadcrumb links back to MCP Overview
    - "Back to MCP Overview" button in header works
